### PR TITLE
Ryan Barnett's datasets

### DIFF
--- a/mod-2/whateverly/1901/RyanDBarnett.js
+++ b/mod-2/whateverly/1901/RyanDBarnett.js
@@ -1,0 +1,4172 @@
+const s1episodes = [
+  {
+     "seasonNum":1,
+     "episodeNum":1,
+     "episodeTitle":"Winter Is Coming",
+     "episodeLink":"/title/tt1480055/",
+     "episodeAirDate":"2011-04-17",
+     "episodeDescription":"Jon Arryn, the Hand of the King, is dead. King Robert Baratheon plans to ask his oldest friend, Eddard Stark, to take Jon's place. Across the sea, Viserys Targaryen plans to wed his sister to a nomadic warlord in exchange for an army.",
+     "openingSequenceLocations":[
+        "King's Landing",
+        "Winterfell",
+        "The Wall",
+        "Pentos"
+     ],
+     "scenes":[
+        {
+           "sceneStart":"0:00:40",
+           "sceneEnd":"0:01:45",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Gared"},
+              {"name":"Waymar Royce"},
+              {"name":"Will"}
+           ]
+        },
+        {
+           "sceneStart":"0:01:45",
+           "sceneEnd":"0:03:24",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Gared"},
+              {"name":"Waymar Royce"},
+              {"name":"Will"}
+           ]
+        },
+        {
+           "sceneStart":"0:03:24",
+           "sceneEnd":"0:03:31",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Will"},
+              {"name":"Wight Wildling Girl", "alive":false}
+           ]
+        },
+        {
+           "sceneStart":"0:03:31",
+           "sceneEnd":"0:03:38",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Will"}
+           ]
+        },
+        {
+           "sceneStart":"0:03:38",
+           "sceneEnd":"0:03:44",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+           ]
+        },
+        {
+           "sceneStart":"0:03:44",
+           "sceneEnd":"0:05:36",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Gared"},
+              {"name":"Waymar Royce"},
+              {"name":"Will"}
+           ]
+        },
+        {
+           "sceneStart":"0:05:36",
+           "sceneEnd":"0:05:41",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Will"}
+           ]
+        },
+        {
+           "sceneStart":"0:05:41",
+           "sceneEnd":"0:05:48",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Gared"},
+              {"name":"Waymar Royce"}
+           ]
+        },
+        {
+           "sceneStart":"0:05:48",
+           "sceneEnd":"0:05:58",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Will"}
+           ]
+        },
+        {
+           "sceneStart":"0:05:58",
+           "sceneEnd":"0:06:21",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Gared"},
+              {
+                 "name":"Waymar Royce",
+                 "alive":false,
+                 "mannerOfDeath":"Back stab",
+                 "killedBy":[
+                    "White Walker"
+                 ]
+              },
+              {"name":"White Walker"}
+           ]
+        },
+        {
+           "sceneStart":"0:06:21",
+           "sceneEnd":"0:06:39",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Will"}
+           ]
+        },
+        {
+           "sceneStart":"0:06:39",
+           "sceneEnd":"0:06:49",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Will"},
+              {"name":"Wight Wildling Girl"}
+           ]
+        },
+        {
+           "sceneStart":"0:06:49",
+           "sceneEnd":"0:07:45",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Will"},
+              {
+                 "name":"Gared",
+                 "alive":false,
+                 "mannerOfDeath":"Decapitation",
+                 "killedBy":[
+                    "White Walker"
+                 ]
+              },
+              {"name":"White Walker"}
+           ]
+        },
+        {
+           "sceneStart":"0:09:27",
+           "sceneEnd":"0:12:38",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Will"},
+              {"name":"Jon Snow"},
+              {"name":"Bran Stark"},
+              {"name":"Robb Stark"},
+              {"name":"Eddard Stark"},
+              {"name":"Catelyn Stark"},
+              {"name":"Rickon Stark"},
+              {"name":"Sansa Stark"},
+              {"name":"Arya Stark"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Septa Mordane"}
+           ]
+        },
+        {
+           "sceneStart":"0:12:38",
+           "sceneEnd":"0:15:41",
+           "location":"The North",
+           "subLocation":"Outside Winterfell",
+           "characters":[
+              {
+                 "name":"Will",
+                 "alive":false,
+                 "mannerOfDeath":"Decapitation",
+                 "killedBy":[
+                    "Eddard Stark"
+                 ]
+              },
+              {
+                 "name":"Eddard Stark",
+                 "weapon":[
+                    {"action":"has", "name":"Ice"}
+                 ]
+              },
+              {"name":"Robb Stark"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Bran Stark"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Jory Cassel"},
+              {"name":"Jon Snow"}
+           ]
+        },
+        {
+           "sceneStart":"0:15:41",
+           "sceneEnd":"0:18:44",
+           "location":"The North",
+           "subLocation":"Outside Winterfell",
+           "characters":[
+              {"name":"Jon Snow"},
+              {
+                 "name":"Eddard Stark",
+                 "weapon":[
+                    {"action":"has", "name":"Ice"}
+                 ]
+              },
+              {"name":"Theon Greyjoy"},
+              {"name":"Bran Stark"},
+              {"name":"Robb Stark"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Jory Cassel"},
+              {"name":"Grey Wind"},
+              {"name":"Lady"},
+              {"name":"Nymeria"},
+              {"name":"Summer"},
+              {"name":"Shaggydog"},
+              {"name":"Ghost"}
+           ]
+        },
+        {
+           "sceneStart":"0:18:44",
+           "sceneEnd":"0:20:45",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Jon Arryn",
+                 "alive":false,
+                 "title":"Hand",
+                 "mannerOfDeath":"Poison",
+                 "killedBy":[
+                    "Lysa Arryn"
+                 ]
+              },
+              {"name":"Cersei Lannister"},
+              {"name":"Jaime Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:20:45",
+           "sceneEnd":"0:22:43",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {
+                 "name":"Eddard Stark",
+                 "weapon":[
+                    {"action":"has", "name":"Ice"}
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:22:43",
+           "sceneEnd":"0:23:09",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Maester Luwin"}
+           ]
+        },
+        {
+           "sceneStart":"0:23:09",
+           "sceneEnd":"0:23:39",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Robb Stark"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Jon Snow"}
+           ]
+        },
+        {
+           "sceneStart":"0:23:39",
+           "sceneEnd":"0:29:16",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Catelyn Stark"},
+              {"name":"Maester Luwin"},
+              {"name":"Summer"},
+              {"name":"Arya Stark"},
+              {
+                 "name":"Joffrey Baratheon",
+                 "weapon":[
+                    {"action":"has", "name":"Lion's Tooth"}
+                 ]
+              },
+              {"name":"Sandor Clegane"},
+              {"name":"Rickon Stark"},
+              {"name":"Eddard Stark"},
+              {"name":"Sansa Stark"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Jon Snow"},
+              {"name":"Jory Cassel"},
+              {"name":"Hodor"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Cersei Lannister"},
+              {"name":"Jaime Lannister"},
+              {"name":"Myrcella Baratheon"},
+              {"name":"Tommen Baratheon"}
+           ]
+        },
+        {
+           "sceneStart":"0:29:16",
+           "sceneEnd":"0:30:47",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Eddard Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:30:47",
+           "sceneEnd":"0:32:57",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Jaime Lannister"},
+              {
+                 "name":"Tyrion Lannister",
+                 "sex":{
+                    "with":["Ros"],
+                    "type":"paid",
+                    "when":"present"
+                 }
+              },
+              {
+                 "name":"Ros",
+                 "sex":{
+                    "with":["Tyrion Lannister"],
+                    "type":"paid",
+                    "when":"present"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:32:57",
+           "sceneEnd":"0:33:45",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Eddard Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:33:45",
+           "sceneEnd":"0:36:17",
+           "location":"Pentos",
+           "characters":[
+              {"name":"Daenerys Targaryen"},
+              {"name":"Viserys Targaryen"}
+           ]
+        },
+        {
+           "sceneStart":"0:36:17",
+           "sceneEnd":"0:38:23",
+           "location":"Pentos",
+           "characters":[
+              {"name":"Daenerys Targaryen"},
+              {"name":"Viserys Targaryen"},
+              {"name":"Illyrio Mopatis"},
+              {"name":"Khal Drogo", "title":"Khal"},
+              {"name":"Qotho"}
+           ]
+        },
+        {
+           "sceneStart":"0:38:23",
+           "sceneEnd":"0:40:05",
+           "location":"Pentos",
+           "characters":[
+              {"name":"Viserys Targaryen"},
+              {"name":"Illyrio Mopatis"},
+              {"name":"Daenerys Targaryen"}
+           ]
+        },
+        {
+           "sceneStart":"0:40:05",
+           "sceneEnd":"0:40:56",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Sansa Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:40:56",
+           "sceneEnd":"0:41:19",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Catelyn Stark"},
+              {"name":"Cersei Lannister"},
+              {"name":"Rodrik Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:41:19",
+           "sceneEnd":"0:44:14",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Benjen Stark"},
+              {"name":"Tyrion Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:44:14",
+           "sceneEnd":"0:47:28",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Rodrik Cassel"},
+              {"name":"Benjen Stark"},
+              {"name":"Eddard Stark"},
+              {"name":"Robb Stark"},
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Catelyn Stark"},
+              {"name":"Cersei Lannister"},
+              {"name":"Sansa Stark"},
+              {"name":"Joffrey Baratheon"},
+              {"name":"Jaime Lannister"},
+              {"name":"Arya Stark"},
+              {"name":"Theon Greyjoy"}
+           ]
+        },
+        {
+           "sceneStart":"0:47:28",
+           "sceneEnd":"0:50:29",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Eddard Stark"},
+              {"name":"Catelyn Stark"},
+              {"name":"Maester Luwin"}
+           ]
+        },
+        {
+           "sceneStart":"0:50:29",
+           "sceneEnd":"0:56:05",
+           "location":"Pentos",
+           "characters":[
+              {
+                 "name":"Khal Drogo",
+                 "title":"Khal",
+                 "married":{
+                    "to":"Daenerys Targaryen",
+                    "when":"present",
+                    "type":"arranged",
+                    "consummated":true
+                 }
+              },
+              {
+                 "name":"Daenerys Targaryen",
+                 "title":"Khaleesi",
+                 "married":{
+                    "to":"Khal Drogo",
+                    "when":"present",
+                    "type":"arranged",
+                    "consummated":true
+                 }
+              },
+              {"name":"Viserys Targaryen"},
+              {"name":"Illyrio Mopatis"},
+              {"name":"Qotho"},
+              {"name":"Jorah Mormont"},
+              {"name":"Drogon", "born":false},
+              {"name":"Rhaegal", "born":false},
+              {"name":"Viserion", "born":false}
+           ]
+        },
+        {
+           "sceneStart":"0:56:05",
+           "sceneEnd":"0:57:48",
+           "location":"Pentos",
+           "characters":[
+              {
+                 "name":"Khal Drogo",
+                 "title":"Khal",
+                 "sex":{
+                    "with":["Daenerys Targaryen"],
+                    "when":"present",
+                    "type":"rape"
+                 }
+              },
+              {
+                 "name":"Daenerys Targaryen",
+                 "title":"Khaleesi",
+                 "sex":{
+                    "with":["Khal Drogo"],
+                    "when":"present",
+                    "type":"rape"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:57:48",
+           "sceneEnd":"0:59:06",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Sandor Clegane"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Eddard Stark"},
+              {"name":"Benjen Stark"},
+              {"name":"Robb Stark"},
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Bran Stark"},
+              {"name":"Summer"}
+           ]
+        },
+        {
+           "sceneStart":"0:59:06",
+           "sceneEnd":"1:00:57",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Summer"},
+              {
+                 "name":"Jaime Lannister",
+                 "sex":{
+                    "with":["Cersei Lannister"],
+                    "when":"present",
+                    "type":"love"
+                 }
+              },
+              {
+                 "name":"Cersei Lannister",
+                 "sex":{
+                    "with":["Jaime Lannister"],
+                    "when":"present",
+                    "type":"love"
+                 }
+              }
+           ]
+        }
+     ]
+  },
+  {
+     "seasonNum":1,
+     "episodeNum":2,
+     "episodeTitle":"The Kingsroad",
+     "episodeLink":"/title/tt1668746/",
+     "episodeAirDate":"2011-04-24",
+     "episodeDescription":"While Bran recovers from his fall, Ned takes only his daughters to King's Landing. Jon Snow goes with his uncle Benjen to The Wall. Tyrion joins them.",
+     "openingSequenceLocations":[
+        "King's Landing",
+        "Winterfell",
+        "The Wall",
+        "Vaes Dothrak"
+     ],
+     "scenes":[
+        {
+           "sceneStart":"0:02:22",
+           "sceneEnd":"0:05:28",
+           "location":"The Dothraki Sea",
+           "characters":[
+              {"name":"Jorah Mormont"},
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Khal Drogo", "title":"Khal"},
+              {"name":"Viserys Targaryen"},
+              {"name":"Doreah"},
+              {"name":"Irri"},
+              {"name":"Jhiqui"}
+           ]
+        },
+        {
+           "sceneStart":"0:05:28",
+           "sceneEnd":"0:07:05",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {
+                 "name":"Joffrey Baratheon",
+                 "weapon":[
+                    {"action":"has", "name":"Lion's Tooth"}
+                 ]
+              },
+              {"name":"Sandor Clegane"}
+           ]
+        },
+        {
+           "sceneStart":"0:07:05",
+           "sceneEnd":"0:09:18",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Jaime Lannister"},
+              {"name":"Cersei Lannister"},
+              {"name":"Tommen Baratheon"},
+              {"name":"Myrcella Baratheon"}
+           ]
+        },
+        {
+           "sceneStart":"0:09:18",
+           "sceneEnd":"0:11:44",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Bran Stark"},
+              {"name":"Cersei Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:11:44",
+           "sceneEnd":"0:13:26",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Jaime Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:13:26",
+           "sceneEnd":"0:15:43",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {
+                 "name":"Arya Stark",
+                 "weapon":[
+                    {"action":"receives", "name":"Needle"}
+                 ]
+              },
+              {"name":"Nymeria"},
+              {
+                 "name":"Jon Snow",
+                 "weapon":[
+                    {"action":"gives", "name":"Needle"}
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:15:43",
+           "sceneEnd":"0:19:22",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Jon Snow"},
+              {"name":"Bran Stark"},
+              {"name":"Eddard Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:19:22",
+           "sceneEnd":"0:20:07",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Robb Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:20:07",
+           "sceneEnd":"0:21:51",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Benjen Stark"},
+              {"name":"Eddard Stark"},
+              {"name":"Jon Snow"}
+           ]
+        },
+        {
+           "sceneStart":"0:21:51",
+           "sceneEnd":"0:25:10",
+           "location":"The North",
+           "subLocation":"The Kingsroad South to King's Landing",
+           "characters":[
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Eddard Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:25:10",
+           "sceneEnd":"0:25:56",
+           "location":"The Dothraki Sea",
+           "subLocation":"Dothraki Camp",
+           "characters":[
+              {
+                 "name":"Khal Drogo",
+                 "title":"Khal",
+                 "sex":{
+                    "with":["Daenerys Targaryen"],
+                    "when":"present",
+                    "type":"rape"
+                 }
+              },
+              {
+                 "name":"Daenerys Targaryen",
+                 "title":"Khaleesi",
+                 "sex":{
+                    "with":["Khal Drogo"],
+                    "when":"present",
+                    "type":"rape"
+                 }
+              },
+              {"name":"Drogon", "born":false},
+              {"name":"Rhaegal", "born":false},
+              {"name":"Viserion", "born":false}
+           ]
+        },
+        {
+           "sceneStart":"0:25:56",
+           "sceneEnd":"0:29:16",
+           "location":"The North",
+           "subLocation":"North to the Wall",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Ghost"},
+              {"name":"Benjen Stark"},
+              {"name":"Tyrion Lannister"},
+              {"name":"Rast"}
+           ]
+        },
+        {
+           "sceneStart":"0:29:16",
+           "sceneEnd":"0:32:28",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Bran Stark"},
+              {"name":"Maester Luwin"},
+              {"name":"Robb Stark"},
+              {
+                 "name":"Catspaw Assassin",
+                 "alive":false,
+                 "mannerOfDeath":"Mauling",
+                 "killedBy":[
+                    "Summer"
+                 ],
+                 "weapon":[
+                    {"action":"has", "name":"Valyrian Steel Dagger"}
+                 ]
+              },
+              {"name":"Summer"}
+           ]
+        },
+        {
+           "sceneStart":"0:32:28",
+           "sceneEnd":"0:34:21",
+           "location":"The Dothraki Sea",
+           "subLocation":"Dothraki Camp",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Doreah"},
+              {"name":"Irri"},
+              {"name":"Jhiqui"},
+              {"name":"Drogon", "born":false},
+              {"name":"Rhaegal", "born":false},
+              {"name":"Viserion", "born":false}
+           ]
+        },
+        {
+           "sceneStart":"0:34:21",
+           "sceneEnd":"0:34:53",
+           "location":"The Wall",
+           "subLocation":"The Gift",
+           "characters":[
+              {"name":"Benjen Stark"},
+              {"name":"Jon Snow"},
+              {"name":"Tyrion Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:34:53",
+           "sceneEnd":"0:36:12",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Catelyn Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:36:12",
+           "sceneEnd":"0:38:01",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Robb Stark"},
+              {"name":"Maester Luwin"},
+              {
+                 "name":"Rodrik Cassel",
+                 "weapon":[
+                    {"action":"has", "name":"Valyrian Steel Dagger"}
+                 ]
+              },
+              {"name":"Theon Greyjoy"}
+           ]
+        },
+        {
+           "sceneStart":"0:38:01",
+           "sceneEnd":"0:38:54",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Bran Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:38:54",
+           "sceneEnd":"0:40:37",
+           "location":"The Dothraki Sea",
+           "subLocation":"Dothraki Camp",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Doreah"}
+           ]
+        },
+        {
+           "sceneStart":"0:40:37",
+           "sceneEnd":"0:42:47",
+           "location":"The Dothraki Sea",
+           "subLocation":"Dothraki Camp",
+           "characters":[
+              {"name":"Drogon", "born":false},
+              {"name":"Rhaegal", "born":false},
+              {"name":"Viserion", "born":false},
+              {
+                 "name":"Khal Drogo",
+                 "title":"Khal",
+                 "sex":{
+                    "with":["Daenerys Targaryen"],
+                    "when":"present",
+                    "type":"love"
+                 }
+              },
+              {
+                 "name":"Daenerys Targaryen",
+                 "title":"Khaleesi",
+                 "sex":{
+                    "with":["Khal Drogo"],
+                    "when":"present",
+                    "type":"love"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:42:47",
+           "sceneEnd":"0:44:38",
+           "location":"The Riverlands",
+           "subLocation":"Crossroads Inn",
+           "characters":[
+              {"name":"Sansa Stark"},
+              {"name":"Lady"},
+              {
+                 "name":"Joffrey Baratheon",
+                 "weapon":[
+                    {"action":"has", "name":"Lion's Tooth"}
+                 ]
+              },
+              {"name":"Sandor Clegane"},
+              {"name":"Ilyn Payne"}
+           ]
+        },
+        {
+           "sceneStart":"0:44:38",
+           "sceneEnd":"0:47:21",
+           "location":"The Riverlands",
+           "subLocation":"Crossroads Inn",
+           "characters":[
+              {"name":"Arya Stark"},
+              {"name":"Mycah"},
+              {
+                 "name":"Joffrey Baratheon",
+                 "weapon":[
+                    {"action":"loses", "name":"Lion's Tooth"}
+                 ]
+              },
+              {"name":"Sansa Stark"},
+              {"name":"Nymeria"}
+           ]
+        },
+        {
+           "sceneStart":"0:47:21",
+           "sceneEnd":"0:48:12",
+           "location":"The Riverlands",
+           "subLocation":"Crossroads Inn",
+           "characters":[
+              {"name":"Arya Stark"},
+              {"name":"Nymeria"}
+           ]
+        },
+        {
+           "sceneStart":"0:48:12",
+           "sceneEnd":"0:48:50",
+           "location":"The Riverlands",
+           "subLocation":"Crossroads Inn",
+           "characters":[
+              {"name":"Eddard Stark"},
+              {"name":"Jory Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:48:50",
+           "sceneEnd":"0:52:59",
+           "location":"The Riverlands",
+           "subLocation":"Crossroads Inn",
+           "characters":[
+              {"name":"Eddard Stark"},
+              {"name":"Arya Stark"},
+              {"name":"Joffrey Baratheon"},
+              {"name":"Cersei Lannister"},
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Ilyn Payne"},
+              {"name":"Sansa Stark"},
+              {"name":"Jory Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:52:59",
+           "sceneEnd":"0:53:30",
+           "location":"The Riverlands",
+           "subLocation":"Crossroads Inn",
+           "characters":[
+              {"name":"Sandor Clegane"},
+              {
+                 "name":"Mycah",
+                 "alive":false,
+                 "mannerOfDeath":"Horse",
+                 "killedBy":[
+                    "Sandor Clegane"
+                 ]
+              },
+              {"name":"Eddard Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:53:30",
+           "sceneEnd":"0:53:41",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Summer"}
+           ]
+        },
+        {
+           "sceneStart":"0:53:41",
+           "sceneEnd":"0:54:09",
+           "location":"The Riverlands",
+           "subLocation":"Crossroads Inn",
+           "characters":[
+              {"name":"Lady"},
+              {"name":"Eddard Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:54:09",
+           "sceneEnd":"0:54:25",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Summer"}
+           ]
+        },
+        {
+           "sceneStart":"0:54:25",
+           "sceneEnd":"0:54:35",
+           "location":"The Riverlands",
+           "subLocation":"Crossroads Inn",
+           "characters":[
+              {"name":"Eddard Stark"},
+              {
+                 "name":"Lady",
+                 "alive":false,
+                 "mannerOfDeath":"Stab",
+                 "killedBy":[
+                    "Eddard Stark"
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:54:35",
+           "sceneEnd":"0:54:44",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Summer"}
+           ]
+        }
+     ]
+  },
+  {
+     "seasonNum":1,
+     "episodeNum":3,
+     "episodeTitle":"Lord Snow",
+     "episodeLink":"/title/tt1829962/",
+     "episodeAirDate":"2011-05-01",
+     "episodeDescription":"Lord Stark and his daughters arrive at King's Landing to discover the intrigues of the king's realm.",
+     "openingSequenceLocations":[
+        "King's Landing",
+        "Winterfell",
+        "The Wall",
+        "Vaes Dothrak"
+     ],
+     "scenes":[
+        {
+           "sceneStart":"0:01:47",
+           "sceneEnd":"0:02:42",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark"},
+              {"name":"Sansa Stark"},
+              {"name":"Arya Stark"},
+              {"name":"Jory Cassel"},
+              {"name":"Septa Mordane"},
+              {"name":"Royal Steward"}
+           ]
+        },
+        {
+           "sceneStart":"0:02:42",
+           "sceneEnd":"0:05:17",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark"},
+              {"name":"Jaime Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:05:17",
+           "sceneEnd":"0:08:11",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Lord Varys"},
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Renly Baratheon"},
+              {"name":"Petyr Baelish"}
+           ]
+        },
+        {
+           "sceneStart":"0:08:11",
+           "sceneEnd":"0:10:50",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Joffrey Baratheon"},
+              {"name":"Cersei Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:10:50",
+           "sceneEnd":"0:12:11",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Arya Stark"},
+              {"name":"Sansa Stark"},
+              {"name":"Septa Mordane"},
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        },
+        {
+           "sceneStart":"0:12:11",
+           "sceneEnd":"0:15:48",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Arya Stark",
+                 "weapon":[
+                    {"action":"has", "name":"Needle"}
+                 ]
+              },
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        },
+        {
+           "sceneStart":"0:15:48",
+           "sceneEnd":"0:18:50",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Old Nan"},
+              {"name":"Robb Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:18:50",
+           "sceneEnd":"0:21:42",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Rodrik Cassel",
+                 "weapon":[
+                    {"action":"gives", "name":"Valyrian Steel Dagger"}
+                 ]
+              },
+              {"name":"Catelyn Stark"},
+              {"name":"Petyr Baelish"},
+              {
+                 "name":"Lord Varys",
+                 "weapon":[
+                    {"action":"receives", "name":"Valyrian Steel Dagger"}
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:21:42",
+           "sceneEnd":"0:23:18",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Jeor Mormont"},
+              {"name":"Alliser Thorne"},
+              {"name":"Jon Snow"},
+              {"name":"Pypar"},
+              {"name":"Grenn"},
+              {"name":"Rast"}
+           ]
+        },
+        {
+           "sceneStart":"0:23:18",
+           "sceneEnd":"0:24:07",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Petyr Baelish"}
+           ]
+        },
+        {
+           "sceneStart":"0:24:07",
+           "sceneEnd":"0:24:42",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Petyr Baelish"},
+              {"name":"Catelyn Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:24:42",
+           "sceneEnd":"0:26:42",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Rast"},
+              {"name":"Grenn"},
+              {"name":"Pypar"},
+              {"name":"Tyrion Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:26:42",
+           "sceneEnd":"0:27:19",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Petyr Baelish"},
+              {"name":"Catelyn Stark"},
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        },
+        {
+           "sceneStart":"0:27:19",
+           "sceneEnd":"0:28:28",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Cersei Lannister"},
+              {"name":"Jaime Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:28:28",
+           "sceneEnd":"0:30:07",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Catelyn Stark"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Jory Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:30:07",
+           "sceneEnd":"0:34:39",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Barristan Selmy"},
+              {"name":"Lancel Lannister"},
+              {"name":"Jaime Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:34:39",
+           "sceneEnd":"0:38:17",
+           "location":"The Dothraki Sea",
+           "characters":[
+              {"name":"Khal Drogo", "title":"Khal"},
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Jorah Mormont"},
+              {"name":"Viserys Targaryen"},
+              {"name":"Rakharo"},
+              {"name":"Irri"}
+           ]
+        },
+        {
+           "sceneStart":"0:38:17",
+           "sceneEnd":"0:41:52",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Benjen Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:41:52",
+           "sceneEnd":"0:45:46",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Yoren"},
+              {"name":"Benjen Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:45:46",
+           "sceneEnd":"0:46:24",
+           "location":"The Dothraki Sea",
+           "subLocation":"Dothraki Camp",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Irri"}
+           ]
+        },
+        {
+           "sceneStart":"0:46:24",
+           "sceneEnd":"0:48:38",
+           "location":"The Dothraki Sea",
+           "subLocation":"Dothraki Camp",
+           "characters":[
+              {"name":"Jorah Mormont"},
+              {"name":"Rakharo"},
+              {"name":"Irri"}
+           ]
+        },
+        {
+           "sceneStart":"0:48:38",
+           "sceneEnd":"0:50:41",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Jon Snow"},
+              {"name":"Pypar"},
+              {"name":"Grenn"},
+              {"name":"Rast"},
+              {"name":"Maester Aemon"},
+              {"name":"Jeor Mormont"}
+           ]
+        },
+        {
+           "sceneStart":"0:50:41",
+           "sceneEnd":"0:51:30",
+           "location":"The Dothraki Sea",
+           "subLocation":"Dothraki Camp",
+           "characters":[
+              {"name":"Drogon", "born":false},
+              {"name":"Rhaegal", "born":false},
+              {"name":"Viserion", "born":false},
+              {
+                 "name":"Daenerys Targaryen",
+                 "title":"Khaleesi",
+                 "sex":{
+                    "with":["Khal Drogo"],
+                    "when":"past",
+                    "type":"love"
+                 }
+              },
+              {
+                 "name":"Khal Drogo",
+                 "title":"Khal",
+                 "sex":{
+                    "with":["Daenerys Targaryen"],
+                    "when":"past",
+                    "type":"love"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:51:30",
+           "sceneEnd":"0:52:32",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Jon Snow"}
+           ]
+        },
+        {
+           "sceneStart":"0:52:32",
+           "sceneEnd":"0:56:04",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Arya Stark"},
+              {"name":"Syrio Forel"},
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        }
+     ]
+  },
+  {
+     "seasonNum":1,
+     "episodeNum":4,
+     "episodeTitle":"Cripples, Bastards, and Broken Things",
+     "episodeLink":"/title/tt1829963/",
+     "episodeAirDate":"2011-05-08",
+     "episodeDescription":"Eddard investigates Jon Arryn's murder. Jon befriends Samwell Tarly, a coward who has come to join the Night's Watch.",
+     "openingSequenceLocations":[
+        "King's Landing",
+        "Winterfell",
+        "The Wall",
+        "Vaes Dothrak"
+     ],
+     "scenes":[
+        {
+           "sceneStart":"0:01:47",
+           "sceneEnd":"0:02:36",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "greensight":true,
+           "characters":[
+              {"name":"Three-Eyed Raven"},
+              {"name":"Bran Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:02:36",
+           "sceneEnd":"0:03:30",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Summer"},
+              {"name":"Old Nan"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Hodor"}
+           ]
+        },
+        {
+           "sceneStart":"0:03:30",
+           "sceneEnd":"0:05:13",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Robb Stark"},
+              {"name":"Maester Luwin"},
+              {"name":"Yoren"},
+              {"name":"Grey Wind"},
+              {"name":"Hodor"},
+              {"name":"Bran Stark"},
+              {"name":"Theon Greyjoy"}
+           ]
+        },
+        {
+           "sceneStart":"0:05:13",
+           "sceneEnd":"0:06:40",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Theon Greyjoy"},
+              {"name":"Tyrion Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:06:40",
+           "sceneEnd":"0:10:11",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Grenn"},
+              {"name":"Alliser Thorne"},
+              {"name":"Samwell Tarly"},
+              {"name":"Pypar"},
+              {"name":"Rast"}
+           ]
+        },
+        {
+           "sceneStart":"0:10:11",
+           "sceneEnd":"0:11:21",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Khal Drogo", "title":"Khal"},
+              {"name":"Jorah Mormont"},
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Viserys Targaryen"}
+           ]
+        },
+        {
+           "sceneStart":"0:11:21",
+           "sceneEnd":"0:12:17",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Jorah Mormont"},
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"}
+           ]
+        },
+        {
+           "sceneStart":"0:12:17",
+           "sceneEnd":"0:17:10",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {
+                 "name":"Viserys Targaryen",
+                 "sex":{
+                    "with":["Doreah"],
+                    "when":"present",
+                    "type":"paid"
+                 }
+              },
+              {
+                 "name":"Doreah",
+                 "sex":{
+                    "with":["Viserys Targaryen"],
+                    "when":"present",
+                    "type":"paid"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:17:10",
+           "sceneEnd":"0:18:53",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Sansa Stark"},
+              {"name":"Septa Mordane"}
+           ]
+        },
+        {
+           "sceneStart":"0:18:53",
+           "sceneEnd":"0:21:17",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Petyr Baelish"},
+              {"name":"Renly Baratheon"},
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Janos Slynt"},
+              {"name":"Lord Varys"}
+           ]
+        },
+        {
+           "sceneStart":"0:21:17",
+           "sceneEnd":"0:23:42",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        },
+        {
+           "sceneStart":"0:23:42",
+           "sceneEnd":"0:25:30",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Arya Stark"},
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        },
+        {
+           "sceneStart":"0:25:30",
+           "sceneEnd":"0:27:42",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Samwell Tarly"}
+           ]
+        },
+        {
+           "sceneStart":"0:27:42",
+           "sceneEnd":"0:29:30",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Petyr Baelish"}
+           ]
+        },
+        {
+           "sceneStart":"0:29:30",
+           "sceneEnd":"0:30:03",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Hugh of the Vale"},
+              {"name":"Jory Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:30:03",
+           "sceneEnd":"0:30:24",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Jory Cassel"},
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        },
+        {
+           "sceneStart":"0:30:24",
+           "sceneEnd":"0:32:21",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Gendry"},
+              {"name":"Tobho Mott"}
+           ]
+        },
+        {
+           "sceneStart":"0:32:21",
+           "sceneEnd":"0:32:30",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Jory Cassel"},
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        },
+        {
+           "sceneStart":"0:32:30",
+           "sceneEnd":"0:34:27",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Jaime Lannister"},
+              {"name":"Jory Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:34:27",
+           "sceneEnd":"0:35:28",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Pypar"},
+              {"name":"Grenn"},
+              {"name":"Rast"}
+           ]
+        },
+        {
+           "sceneStart":"0:35:28",
+           "sceneEnd":"0:35:54",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Rast"},
+              {"name":"Jon Snow"},
+              {"name":"Grenn"},
+              {"name":"Pypar"},
+              {"name":"Ghost"}
+           ]
+        },
+        {
+           "sceneStart":"0:35:54",
+           "sceneEnd":"0:37:12",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Samwell Tarly"},
+              {"name":"Alliser Thorne"},
+              {"name":"Rast"},
+              {"name":"Jon Snow"},
+              {"name":"Pypar"},
+              {"name":"Grenn"}
+           ]
+        },
+        {
+           "sceneStart":"0:37:12",
+           "sceneEnd":"0:38:33",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Viserys Targaryen"},
+              {"name":"Doreah"},
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Irri"}
+           ]
+        },
+        {
+           "sceneStart":"0:38:33",
+           "sceneEnd":"0:44:32",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Samwell Tarly"},
+              {"name":"Jon Snow"},
+              {"name":"Alliser Thorne"}
+           ]
+        },
+        {
+           "sceneStart":"0:44:32",
+           "sceneEnd":"0:45:38",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Jorah Mormont"}
+           ]
+        },
+        {
+           "sceneStart":"0:45:38",
+           "sceneEnd":"0:49:47",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Robert Baratheon"},
+              {"name":"Cersei Lannister"},
+              {"name":"Tommen Baratheon"},
+              {"name":"Myrcella Baratheon"},
+              {"name":"Barristan Selmy"},
+              {"name":"Joffrey Baratheon"},
+              {"name":"Sansa Stark"},
+              {"name":"Petyr Baelish"},
+              {"name":"Septa Mordane"},
+              {"name":"Arya Stark"},
+              {"name":"Sandor Clegane"},
+              {"name":"Gregor Clegane"},
+              {
+                 "name":"Hugh of the Vale",
+                 "alive":false,
+                 "mannerOfDeath":"Throat stab",
+                 "killedBy":[
+                    "Gregor Clegane"
+                 ]
+              },
+              {"name":"Renly Baratheon"}
+           ]
+        },
+        {
+           "sceneStart":"0:49:47",
+           "sceneEnd":"0:51:27",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Jory Cassel"},
+              {"name":"Cersei Lannister"},
+              {
+                 "name":"Eddard Stark",
+                 "title":"Hand",
+                 "weapon":[
+                    {"action":"has", "name":"Valyrian Steel Dagger"}
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:51:27",
+           "sceneEnd":"0:54:31",
+           "location":"The Riverlands",
+           "subLocation":"Crossroads Inn",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Marillion"},
+              {"name":"Tyrion Lannister"},
+              {"name":"Yoren"},
+              {"name":"Bronn"}
+           ]
+        }
+     ]
+  },
+  {
+     "seasonNum":1,
+     "episodeNum":5,
+     "episodeTitle":"The Wolf and the Lion",
+     "episodeLink":"/title/tt1829964/",
+     "episodeAirDate":"2011-05-15",
+     "episodeDescription":"Catelyn has captured Tyrion and plans to bring him to her sister, Lysa Arryn, at The Vale, to be tried for his, supposed, crimes against Bran. Robert plans to have Daenerys killed, but Eddard refuses to be a part of it and quits.",
+     "openingSequenceLocations":[
+        "King's Landing",
+        "The Eyrie",
+        "Winterfell",
+        "The Wall",
+        "Vaes Dothrak"
+     ],
+     "scenes":[
+        {
+           "sceneStart":"0:01:53",
+           "sceneEnd":"0:02:18",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        },
+        {
+           "sceneStart":"0:02:18",
+           "sceneEnd":"0:02:55",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Hugh of the Vale", "alive":false},
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Barristan Selmy"}
+           ]
+        },
+        {
+           "sceneStart":"0:02:55",
+           "sceneEnd":"0:03:50",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Barristan Selmy"}
+           ]
+        },
+        {
+           "sceneStart":"0:03:50",
+           "sceneEnd":"0:06:23",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Lancel Lannister"},
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        },
+        {
+           "sceneStart":"0:06:23",
+           "sceneEnd":"0:10:22",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Gregor Clegane"},
+              {"name":"Joffrey Baratheon"},
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Sansa Stark"},
+              {"name":"Petyr Baelish"},
+              {"name":"Septa Mordane"},
+              {"name":"Renly Baratheon"},
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Loras Tyrell"},
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Sandor Clegane"},
+              {"name":"Barristan Selmy"},
+              {"name":"Myrcella Baratheon"},
+              {"name":"Tommen Baratheon"}
+           ]
+        },
+        {
+           "sceneStart":"0:10:22",
+           "sceneEnd":"0:13:40",
+           "location":"The Vale",
+           "subLocation":"Eastern Road",
+           "characters":[
+              {"name":"Marillion"},
+              {"name":"Tyrion Lannister"},
+              {"name":"Catelyn Stark"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Bronn"}
+           ]
+        },
+        {
+           "sceneStart":"0:13:40",
+           "sceneEnd":"0:16:15",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Maester Luwin"},
+              {"name":"Theon Greyjoy"}
+           ]
+        },
+        {
+           "sceneStart":"0:16:15",
+           "sceneEnd":"0:17:59",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {
+                 "name":"Ros",
+                 "sex":{
+                    "with":["Theon Greyjoy"],
+                    "when":"present",
+                    "type":"paid"
+                 }
+              },
+              {
+                 "name":"Theon Greyjoy",
+                 "sex":{
+                    "with":["Ros"],
+                    "when":"present",
+                    "type":"paid"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:17:59",
+           "sceneEnd":"0:18:13",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Arya Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:18:13",
+           "sceneEnd":"0:20:47",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Lord Varys"},
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Jory Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:20:47",
+           "sceneEnd":"0:22:17",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Arya Stark"},
+              {"name":"Lord Varys"},
+              {"name":"Illyrio Mopatis"}
+           ]
+        },
+        {
+           "sceneStart":"0:22:17",
+           "sceneEnd":"0:25:50",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Petyr Baelish"},
+              {"name":"Lord Varys"},
+              {"name":"Renly Baratheon"}
+           ]
+        },
+        {
+           "sceneStart":"0:25:50",
+           "sceneEnd":"0:26:51",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Arya Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:26:51",
+           "sceneEnd":"0:28:35",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Arya Stark"},
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Jory Cassel"},
+              {"name":"Yoren"}
+           ]
+        },
+        {
+           "sceneStart":"0:28:35",
+           "sceneEnd":"0:28:50",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Arya Stark"},
+              {"name":"Jory Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:28:50",
+           "sceneEnd":"0:29:03",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Yoren"}
+           ]
+        },
+        {
+           "sceneStart":"0:29:03",
+           "sceneEnd":"0:30:13",
+           "location":"The Vale",
+           "subLocation":"Eastern Road",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Tyrion Lannister"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Bronn"},
+              {"name":"Vardis Egen"}
+           ]
+        },
+        {
+           "sceneStart":"0:30:13",
+           "sceneEnd":"0:30:31",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Royal Steward"}
+           ]
+        },
+        {
+           "sceneStart":"0:30:31",
+           "sceneEnd":"0:34:06",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Renly Baratheon"},
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Lord Varys"},
+              {"name":"Petyr Baelish"}
+           ]
+        },
+        {
+           "sceneStart":"0:34:06",
+           "sceneEnd":"0:34:15",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Eddard Stark"
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:34:15",
+           "sceneEnd":"0:35:13",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Eddard Stark",
+                 "weapon":[
+                    {"action":"has", "name":"Valyrian Steel Dagger"}
+                 ]
+              },
+              {"name":"Jory Cassel"},
+              {"name":"Petyr Baelish"}
+           ]
+        },
+        {
+           "sceneStart":"0:35:13",
+           "sceneEnd":"0:37:12",
+           "location":"The Vale",
+           "subLocation":"The Eyrie",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Tyrion Lannister"},
+              {"name":"Lysa Arryn"},
+              {"name":"Robin Arryn"},
+              {"name":"Vardis Egen"}
+           ]
+        },
+        {
+           "sceneStart":"0:37:12",
+           "sceneEnd":"0:37:53",
+           "location":"The Vale",
+           "subLocation":"The Eyrie",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Mord"}
+           ]
+        },
+        {
+           "sceneStart":"0:37:53",
+           "sceneEnd":"0:41:50",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Renly Baratheon",
+                 "sex":{
+                    "with":["Loras Tyrell"],
+                    "when":"present",
+                    "type":"love"
+                 }
+              },
+              {
+                 "name":"Loras Tyrell",
+                 "sex":{
+                    "with":["Renly Baratheon"],
+                    "when":"present",
+                    "type":"love"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:41:50",
+           "sceneEnd":"0:48:09",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Cersei Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:48:09",
+           "sceneEnd":"0:49:05",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark"},
+              {"name":"Mhaegen"}
+           ]
+        },
+        {
+           "sceneStart":"0:49:05",
+           "sceneEnd":"0:49:53",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark"},
+              {"name":"Petyr Baelish"},
+              {"name":"Jory Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:49:53",
+           "sceneEnd":"0:53:06",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark"},
+              {
+                 "name":"Jory Cassel",
+                 "alive":false,
+                 "mannerOfDeath":"Eye stab",
+                 "killedBy":[
+                    "Jaime Lannister"
+                 ]
+              },
+              {"name":"Jaime Lannister"},
+              {"name":"Petyr Baelish"}
+           ]
+        }
+     ]
+  },
+  {
+     "seasonNum":1,
+     "episodeNum":6,
+     "episodeTitle":"A Golden Crown",
+     "episodeLink":"/title/tt1837862/",
+     "episodeAirDate":"2011-05-22",
+     "episodeDescription":"While recovering from his battle with Jaime, Eddard is forced to run the kingdom while Robert goes hunting. Tyrion demands a trial by combat for his freedom. Viserys is losing his patience with Drogo.",
+     "openingSequenceLocations":[
+        "King's Landing",
+        "The Eyrie",
+        "Winterfell",
+        "The Wall",
+        "Vaes Dothrak"
+     ],
+     "scenes":[
+        {
+           "sceneStart":"0:01:53",
+           "sceneEnd":"0:06:22",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Cersei Lannister"},
+              {"name":"Robert Baratheon", "title":"King"}
+           ]
+        },
+        {
+           "sceneStart":"0:06:22",
+           "sceneEnd":"0:07:50",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Drogon", "born":false},
+              {"name":"Rhaegal", "born":false},
+              {"name":"Viserion", "born":false},
+              {"name":"Irri"}
+           ]
+        },
+        {
+           "sceneStart":"0:07:50",
+           "sceneEnd":"0:08:25",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "greensight":true,
+           "characters":[
+              {"name":"Three-Eyed Raven"},
+              {"name":"Bran Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:08:25",
+           "sceneEnd":"0:08:36",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Hodor"}
+           ]
+        },
+        {
+           "sceneStart":"0:08:36",
+           "sceneEnd":"0:09:42",
+           "location":"The North",
+           "subLocation":"The Wolfswood",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Robb Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:09:42",
+           "sceneEnd":"0:13:09",
+           "location":"The North",
+           "subLocation":"The Wolfswood",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Osha"},
+              {
+                 "name":"Stiv",
+                 "alive":false,
+                 "mannerOfDeath":"Arrow",
+                 "killedBy":[
+                    "Theon Greyjoy"
+                 ]
+              },
+              {
+                 "name":"Wallen",
+                 "alive":false,
+                 "mannerOfDeath":"Throat slash",
+                 "killedBy":[
+                    "Robb Stark"
+                 ]
+              },
+              {"name":"Robb Stark"},
+              {"name":"Theon Greyjoy"}
+           ]
+        },
+        {
+           "sceneStart":"0:13:09",
+           "sceneEnd":"0:14:16",
+           "location":"The Vale",
+           "subLocation":"The Eyrie",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Mord"}
+           ]
+        },
+        {
+           "sceneStart":"0:14:16",
+           "sceneEnd":"0:16:08",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Syrio Forel"},
+              {"name":"Arya Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:16:08",
+           "sceneEnd":"0:19:39",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Khal Drogo", "title":"Khal"},
+              {"name":"Viserys Targaryen"},
+              {"name":"Jorah Mormont"},
+              {"name":"Irri"},
+              {"name":"Dothraki Crone"},
+              {"name":"Doreah"},
+              {"name":"Rhaego", "born":false}
+           ]
+        },
+        {
+           "sceneStart":"0:19:39",
+           "sceneEnd":"0:21:54",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Drogon", "born":false},
+              {"name":"Rhaegal", "born":false},
+              {"name":"Viserion", "born":false},
+              {"name":"Viserys Targaryen"},
+              {"name":"Jorah Mormont"}
+           ]
+        },
+        {
+           "sceneStart":"0:21:54",
+           "sceneEnd":"0:23:52",
+           "location":"The Vale",
+           "subLocation":"The Eyrie",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Mord"}
+           ]
+        },
+        {
+           "sceneStart":"0:23:52",
+           "sceneEnd":"0:29:27",
+           "location":"The Vale",
+           "subLocation":"The Eyrie",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Lysa Arryn"},
+              {"name":"Catelyn Stark"},
+              {"name":"Robin Arryn"},
+              {"name":"Vardis Egen"},
+              {"name":"Bronn"},
+              {"name":"Rodrik Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:29:27",
+           "sceneEnd":"0:31:20",
+           "location":"The Crownlands",
+           "subLocation":"The Kingswood",
+           "characters":[
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Lancel Lannister"},
+              {"name":"Renly Baratheon"},
+              {"name":"Barristan Selmy"}
+           ]
+        },
+        {
+           "sceneStart":"0:31:20",
+           "sceneEnd":"0:35:25",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Petyr Baelish"},
+              {"name":"Beric Dondarrion"},
+              {"name":"Joss"}
+           ]
+        },
+        {
+           "sceneStart":"0:35:25",
+           "sceneEnd":"0:39:52",
+           "location":"The Vale",
+           "subLocation":"The Eyrie",
+           "characters":[
+              {"name":"Bronn"},
+              {
+                 "name":"Vardis Egen",
+                 "alive":false,
+                 "mannerOfDeath":"Neck stab",
+                 "killedBy":[
+                    "Bronn"
+                 ]
+              },
+              {"name":"Tyrion Lannister"},
+              {"name":"Lysa Arryn"},
+              {"name":"Robin Arryn"},
+              {"name":"Catelyn Stark"},
+              {"name":"Mord"},
+              {"name":"Rodrik Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:39:52",
+           "sceneEnd":"0:42:45",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Septa Mordane"},
+              {"name":"Sansa Stark"},
+              {"name":"Joffrey Baratheon"}
+           ]
+        },
+        {
+           "sceneStart":"0:42:45",
+           "sceneEnd":"0:44:18",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Theon Greyjoy"},
+              {"name":"Ros"}
+           ]
+        },
+        {
+           "sceneStart":"0:44:18",
+           "sceneEnd":"0:46:45",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Sansa Stark"},
+              {"name":"Arya Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:46:45",
+           "sceneEnd":"0:51:30",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Khal Drogo", "title":"Khal"},
+              {"name":"Doreah"},
+              {"name":"Jorah Mormont"},
+              {
+                 "name":"Viserys Targaryen",
+                 "alive":false,
+                 "mannerOfDeath":"Molten gold",
+                 "killedBy":[
+                    "Khal Drogo"
+                 ]
+              },
+              {"name":"Irri"},
+              {"name":"Qotho"}
+           ]
+        }
+     ]
+  },
+  {
+     "seasonNum":1,
+     "episodeNum":7,
+     "episodeTitle":"You Win or You Die",
+     "episodeLink":"/title/tt1837863/",
+     "episodeAirDate":"2011-05-29",
+     "episodeDescription":"Robert has been injured while hunting and is dying. Jon and the others finally take their vows to the Night's Watch. A man, sent by Robert, is captured for trying to poison Daenerys. Furious, Drogo vows to attack the Seven Kingdoms.",
+     "openingSequenceLocations":[
+        "King's Landing",
+        "The Eyrie",
+        "Winterfell",
+        "The Wall",
+        "Vaes Dothrak"
+     ],
+     "scenes":[
+        {
+           "sceneStart":"0:01:52",
+           "sceneEnd":"0:06:35",
+           "location":"The Westerlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {"name":"Jaime Lannister"},
+              {"name":"Tywin Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:06:35",
+           "sceneEnd":"0:09:36",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Cersei Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:09:36",
+           "sceneEnd":"0:14:40",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Petyr Baelish"},
+              {
+                 "name":"Ros",
+                 "sex":{
+                    "with":["Armeca"],
+                    "when":"present",
+                    "type":"paid"
+                 }
+              },
+              {
+                 "name":"Armeca",
+                 "sex":{
+                    "with":["Ros"],
+                    "when":"present",
+                    "type":"paid"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:14:40",
+           "sceneEnd":"0:18:22",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Osha"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Maester Luwin"}
+           ]
+        },
+        {
+           "sceneStart":"0:18:22",
+           "sceneEnd":"0:19:14",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Samwell Tarly"}
+           ]
+        },
+        {
+           "sceneStart":"0:19:14",
+           "sceneEnd":"0:19:59",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Samwell Tarly"},
+              {"name":"Jeor Mormont"}
+           ]
+        },
+        {
+           "sceneStart":"0:19:59",
+           "sceneEnd":"0:20:13",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Renly Baratheon"}
+           ]
+        },
+        {
+           "sceneStart":"0:20:13",
+           "sceneEnd":"0:25:08",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Joffrey Baratheon"},
+              {"name":"Robert Baratheon", "title":"King"},
+              {"name":"Cersei Lannister"},
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Renly Baratheon"},
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Barristan Selmy"}
+           ]
+        },
+        {
+           "sceneStart":"0:25:08",
+           "sceneEnd":"0:26:45",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Barristan Selmy"},
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Renly Baratheon"},
+              {"name":"Lord Varys"}
+           ]
+        },
+        {
+           "sceneStart":"0:26:45",
+           "sceneEnd":"0:28:08",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Khal Drogo", "title":"Khal"},
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"}
+           ]
+        },
+        {
+           "sceneStart":"0:28:08",
+           "sceneEnd":"0:29:12",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Jorah Mormont"},
+              {"name":"Doreah"},
+              {"name":"Rakharo"},
+              {"name":"Irri"}
+           ]
+        },
+        {
+           "sceneStart":"0:29:12",
+           "sceneEnd":"0:29:45",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Jorah Mormont"},
+              {"name":"Little Bird"}
+           ]
+        },
+        {
+           "sceneStart":"0:29:45",
+           "sceneEnd":"0:32:56",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Wine Merchant"},
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Doreah"},
+              {"name":"Irri"},
+              {"name":"Rakharo"},
+              {"name":"Jorah Mormont"}
+           ]
+        },
+        {
+           "sceneStart":"0:32:56",
+           "sceneEnd":"0:38:26",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {
+                 "name":"Jeor Mormont",
+                 "weapon":[
+                    {"action":"has", "name":"Longclaw"}
+                 ]
+              },
+              {"name":"Jon Snow"},
+              {"name":"Pypar"},
+              {"name":"Samwell Tarly"},
+              {"name":"Grenn"},
+              {"name":"Rast"},
+              {"name":"Alliser Thorne"},
+              {"name":"Maester Aemon"},
+              {"name":"Othell Yarwyck"},
+              {"name":"Jaremy Rykker"}
+           ]
+        },
+        {
+           "sceneStart":"0:38:26",
+           "sceneEnd":"0:40:12",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Samwell Tarly"},
+              {"name":"Pypar"}
+           ]
+        },
+        {
+           "sceneStart":"0:40:12",
+           "sceneEnd":"0:42:19",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Renly Baratheon"},
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        },
+        {
+           "sceneStart":"0:42:19",
+           "sceneEnd":"0:45:49",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Eddard Stark",
+                 "title":"Hand",
+                 "weapon":[
+                    {"action":"has", "name":"Valyrian Steel Dagger"}
+                 ]
+              },
+              {"name":"Tomard"},
+              {"name":"Petyr Baelish"}
+           ]
+        },
+        {
+           "sceneStart":"0:45:49",
+           "sceneEnd":"0:46:27",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Samwell Tarly"},
+              {"name":"Ghost"},
+              {"name":"Othell Yarwyck"}
+           ]
+        },
+        {
+           "sceneStart":"0:46:27",
+           "sceneEnd":"0:47:57",
+           "location":"North of the Wall",
+           "subLocation":"The Haunted Forest",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Samwell Tarly"},
+              {"name":"Othell Yarwyck"},
+              {"name":"Ghost"}
+           ]
+        },
+        {
+           "sceneStart":"0:47:57",
+           "sceneEnd":"0:51:36",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Jorah Mormont"},
+              {"name":"Wine Merchant"},
+              {"name":"Rakharo"},
+              {"name":"Khal Drogo", "title":"Khal"}
+           ]
+        },
+        {
+           "sceneStart":"0:51:36",
+           "sceneEnd":"0:51:57",
+           "location":"Vaes Dothrak",
+           "characters":[
+              {"name":"Khal Drogo", "title":"Khal"},
+              {"name":"Jorah Mormont"},
+              {"name":"Qotho"},
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Wine Merchant"}
+           ]
+        },
+        {
+           "sceneStart":"0:51:57",
+           "sceneEnd":"0:52:17",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Varly"},
+              {"name":"Royal Steward"},
+              {
+                 "name":"Robert Baratheon",
+                 "alive":false,
+                 "mannerOfDeath":"Boar",
+                 "killedBy":[
+                    "Boar"
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:52:17",
+           "sceneEnd":"0:52:58",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Petyr Baelish"},
+              {"name":"Lord Varys"}
+           ]
+        },
+        {
+           "sceneStart":"0:52:58",
+           "sceneEnd":"0:53:12",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Petyr Baelish"},
+              {"name":"Lord Varys"},
+              {"name":"Royal Steward"},
+              {"name":"Janos Slynt"}
+           ]
+        },
+        {
+           "sceneStart":"0:53:12",
+           "sceneEnd":"0:56:41",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Petyr Baelish"},
+              {"name":"Lord Varys"},
+              {"name":"Joffrey Baratheon", "title":"King"},
+              {"name":"Cersei Lannister"},
+              {"name":"Barristan Selmy"},
+              {"name":"Sandor Clegane"},
+              {"name":"Royal Steward"},
+              {"name":"Janos Slynt"}
+           ]
+        }
+     ]
+  },
+  {
+     "seasonNum":1,
+     "episodeNum":8,
+     "episodeTitle":"The Pointy End",
+     "episodeLink":"/title/tt1837864/",
+     "episodeAirDate":"2011-06-05",
+     "episodeDescription":"Eddard and his men are betrayed and captured by the Lannisters. When word reaches Robb, he plans to go to war to rescue them. The White Walkers attack The Wall. Tyrion returns to his father with some new friends.",
+     "openingSequenceLocations":[
+        "King's Landing",
+        "The Eyrie",
+        "Winterfell",
+        "The Wall",
+        "Vaes Dothrak"
+     ],
+     "scenes":[
+        {
+           "sceneStart":"0:01:53",
+           "sceneEnd":"0:02:00",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Syrio Forel"},
+              {"name":"Arya Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:02:00",
+           "sceneEnd":"0:02:14",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+           ]
+        },
+        {
+           "sceneStart":"0:02:14",
+           "sceneEnd":"0:02:22",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Syrio Forel"},
+              {"name":"Arya Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:02:22",
+           "sceneEnd":"0:02:37",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Vayon Poole",
+                 "alive":false,
+                 "mannerOfDeath":"Chest stab",
+                 "killedBy":[
+                    "Lannister Guard"
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:02:37",
+           "sceneEnd":"0:03:19",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Septa Mordane"},
+              {"name":"Sansa Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:03:19",
+           "sceneEnd":"0:05:53",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Syrio Forel",
+                 "alive":false,
+                 "killedBy":[
+                    "Meryn Trant"
+                 ]
+              },
+              {"name":"Arya Stark"},
+              {"name":"Meryn Trant"}
+           ]
+        },
+        {
+           "sceneStart":"0:05:53",
+           "sceneEnd":"0:06:14",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Arya Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:06:14",
+           "sceneEnd":"0:06:35",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Sansa Stark"},
+              {"name":"Sandor Clegane"}
+           ]
+        },
+        {
+           "sceneStart":"0:06:35",
+           "sceneEnd":"0:07:12",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Arya Stark"},
+              {
+                 "name":"Red Keep Stableboy",
+                 "alive":false,
+                 "mannerOfDeath":"Chest stab",
+                 "killedBy":[
+                    "Arya Stark"
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:07:12",
+           "sceneEnd":"0:10:14",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Lord Varys"}
+           ]
+        },
+        {
+           "sceneStart":"0:10:14",
+           "sceneEnd":"0:11:30",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Samwell Tarly"},
+              {"name":"Jeor Mormont"},
+              {"name":"Jon Snow"},
+              {"name":"Othor", "alive":false},
+              {"name":"Jafer Flowers", "alive":false},
+              {"name":"Othell Yarwyck"}
+           ]
+        },
+        {
+           "sceneStart":"0:11:30",
+           "sceneEnd":"0:12:59",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jeor Mormont"},
+              {"name":"Jon Snow"}
+           ]
+        },
+        {
+           "sceneStart":"0:12:59",
+           "sceneEnd":"0:15:11",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Cersei Lannister"},
+              {"name":"Lord Varys"},
+              {"name":"Petyr Baelish"},
+              {"name":"Sansa Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:15:11",
+           "sceneEnd":"0:16:24",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Robb Stark"},
+              {"name":"Maester Luwin"},
+              {"name":"Theon Greyjoy"}
+           ]
+        },
+        {
+           "sceneStart":"0:16:24",
+           "sceneEnd":"0:16:37",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+           ]
+        },
+        {
+           "sceneStart":"0:16:37",
+           "sceneEnd":"0:18:31",
+           "location":"The Vale",
+           "subLocation":"The Eyrie",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Lysa Arryn"},
+              {"name":"Robin Arryn"}
+           ]
+        },
+        {
+           "sceneStart":"0:18:31",
+           "sceneEnd":"0:19:54",
+           "location":"The Vale",
+           "subLocation":"To the Westerlands",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Bronn"}
+           ]
+        },
+        {
+           "sceneStart":"0:19:54",
+           "sceneEnd":"0:22:45",
+           "location":"The Vale",
+           "subLocation":"To the Westerlands",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Bronn"},
+              {"name":"Shagga"}
+           ]
+        },
+        {
+           "sceneStart":"0:22:45",
+           "sceneEnd":"0:23:53",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Samwell Tarly"},
+              {"name":"Pypar"},
+              {"name":"Jon Snow"},
+              {"name":"Alliser Thorne"},
+              {"name":"Grenn"},
+              {"name":"Jeor Mormont"}
+           ]
+        },
+        {
+           "sceneStart":"0:23:53",
+           "sceneEnd":"0:24:48",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Ghost"},
+              {"name":"Jon Snow"}
+           ]
+        },
+        {
+           "sceneStart":"0:24:48",
+           "sceneEnd":"0:26:14",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Ghost"},
+              {
+                 "name":"Othor",
+                 "alive":false,
+                 "mannerOfDeath":"Burning",
+                 "killedBy":[
+                    "Jon Snow"
+                 ]
+              },
+              {"name":"Jeor Mormont"}
+           ]
+        },
+        {
+           "sceneStart":"0:26:14",
+           "sceneEnd":"0:28:20",
+           "location":"The Dothraki Sea",
+           "subLocation":"Lhazareen Village",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Jorah Mormont"},
+              {"name":"Rakharo"},
+              {"name":"Doreah"},
+              {"name":"Irri"},
+              {"name":"Mirri Maz Duur"},
+              {"name":"Mago"}
+           ]
+        },
+        {
+           "sceneStart":"0:28:20",
+           "sceneEnd":"0:32:33",
+           "location":"The Dothraki Sea",
+           "subLocation":"Lhazareen Village",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Jorah Mormont"},
+              {"name":"Doreah"},
+              {"name":"Irri"},
+              {"name":"Rakharo"},
+              {"name":"Khal Drogo", "title":"Khal"},
+              {
+                 "name":"Mago",
+                 "alive":false,
+                 "mannerOfDeath":"Tongue removal",
+                 "killedBy":[
+                    "Khal Drogo"
+                 ]
+              },
+              {"name":"Qotho"},
+              {"name":"Mirri Maz Duur"}
+           ]
+        },
+        {
+           "sceneStart":"0:32:33",
+           "sceneEnd":"0:34:17",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Grey Wind"},
+              {"name":"Greatjon Umber"},
+              {"name":"Bran Stark"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Robb Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:34:17",
+           "sceneEnd":"0:36:19",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Robb Stark"},
+              {"name":"Rickon Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:36:19",
+           "sceneEnd":"0:38:35",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Osha"},
+              {"name":"Hodor"}
+           ]
+        },
+        {
+           "sceneStart":"0:38:35",
+           "sceneEnd":"0:39:45",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Pypar"},
+              {"name":"Grenn"},
+              {"name":"Rast"},
+              {"name":"Samwell Tarly"}
+           ]
+        },
+        {
+           "sceneStart":"0:39:45",
+           "sceneEnd":"0:40:10",
+           "location":"The North",
+           "subLocation":"The Neck",
+           "altLocation":"Camp of the North",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Rodrik Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:40:10",
+           "sceneEnd":"0:41:18",
+           "location":"The North",
+           "subLocation":"The Neck",
+           "altLocation":"Camp of the North",
+           "characters":[
+              {"name":"Robb Stark"},
+              {"name":"Greatjon Umber"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Catelyn Stark"},
+              {"name":"Rodrik Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:41:18",
+           "sceneEnd":"0:43:21",
+           "location":"The North",
+           "subLocation":"The Neck",
+           "altLocation":"Camp of the North",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Robb Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:43:21",
+           "sceneEnd":"0:44:34",
+           "location":"The Westerlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Bronn"},
+              {"name":"Shagga"},
+              {"name":"Timett"}
+           ]
+        },
+        {
+           "sceneStart":"0:44:34",
+           "sceneEnd":"0:47:52",
+           "location":"The Westerlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Tywin Lannister"},
+              {"name":"Bronn"},
+              {"name":"Shagga"},
+              {"name":"Kevan Lannister"},
+              {"name":"Timett"},
+              {"name":"Chella"},
+              {"name":"Lannister Messenger"}
+           ]
+        },
+        {
+           "sceneStart":"0:47:52",
+           "sceneEnd":"0:48:25",
+           "location":"The North",
+           "subLocation":"The Neck",
+           "altLocation":"Camp of the North",
+           "characters":[
+              {"name":"Rodrik Cassel"},
+              {"name":"Catelyn Stark"},
+              {"name":"Greatjon Umber"},
+              {"name":"Robb Stark"},
+              {"name":"Theon Greyjoy"}
+           ]
+        },
+        {
+           "sceneStart":"0:48:25",
+           "sceneEnd":"0:48:32",
+           "location":"The North",
+           "subLocation":"The Neck",
+           "altLocation":"Camp of the North",
+           "characters":[
+              {"name":"Lannister Scout"}
+           ]
+        },
+        {
+           "sceneStart":"0:48:32",
+           "sceneEnd":"0:50:40",
+           "location":"The North",
+           "subLocation":"The Neck",
+           "altLocation":"Camp of the North",
+           "characters":[
+              {"name":"Robb Stark"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Greatjon Umber"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Catelyn Stark"},
+              {"name":"Lannister Scout"}
+           ]
+        },
+        {
+           "sceneStart":"0:50:40",
+           "sceneEnd":"0:50:50",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"}
+           ]
+        },
+        {
+           "sceneStart":"0:50:50",
+           "sceneEnd":"0:56:59",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Sansa Stark"},
+              {"name":"Joffrey Baratheon", "title":"King"},
+              {"name":"Cersei Lannister"},
+              {"name":"Sandor Clegane"},
+              {"name":"Janos Slynt"},
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Lord Varys"},
+              {"name":"Petyr Baelish"},
+              {"name":"Barristan Selmy"},
+              {"name":"Royal Steward"},
+              {"name":"Meryn Trant"}
+           ]
+        }
+     ]
+  },
+  {
+     "seasonNum":1,
+     "episodeNum":9,
+     "episodeTitle":"Baelor",
+     "episodeLink":"/title/tt1851398/",
+     "episodeAirDate":"2011-06-12",
+     "episodeDescription":"Robb goes to war against the Lannisters. Jon finds himself struggling on deciding if his place is with Robb or the Night's Watch. Drogo has fallen ill from a fresh battle wound. Daenerys is desperate to save him.",
+     "openingSequenceLocations":[
+        "King's Landing",
+        "The Twins",
+        "Winterfell",
+        "The Wall",
+        "Vaes Dothrak"
+     ],
+     "scenes":[
+        {
+           "sceneStart":"0:02:24",
+           "sceneEnd":"0:06:25",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Eddard Stark", "title":"Hand"},
+              {"name":"Lord Varys"}
+           ]
+        },
+        {
+           "sceneStart":"0:06:25",
+           "sceneEnd":"0:08:12",
+           "location":"The Riverlands",
+           "subLocation":"The Twins",
+           "characters":[
+              {"name":"Theon Greyjoy"},
+              {"name":"Robb Stark"},
+              {"name":"Catelyn Stark"},
+              {"name":"Greatjon Umber"},
+              {"name":"Rodrik Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:08:12",
+           "sceneEnd":"0:09:48",
+           "location":"The Riverlands",
+           "subLocation":"The Twins",
+           "characters":[
+              {"name":"Walder Frey"},
+              {"name":"Joyeuse Erenford"},
+              {"name":"Catelyn Stark"},
+              {"name":"Stevron Frey"},
+              {"name":"Ryger Rivers"}
+           ]
+        },
+        {
+           "sceneStart":"0:09:48",
+           "sceneEnd":"0:11:41",
+           "location":"The Riverlands",
+           "subLocation":"The Twins",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Walder Frey"}
+           ]
+        },
+        {
+           "sceneStart":"0:11:41",
+           "sceneEnd":"0:13:56",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {
+                 "name":"Jon Snow",
+                 "weapon":[
+                    {"action":"receives", "name":"Longclaw"}
+                 ]
+              },
+              {
+                 "name":"Jeor Mormont",
+                 "weapon":[
+                    {"action":"gives", "name":"Longclaw"}
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:13:56",
+           "sceneEnd":"0:14:12",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {
+                 "name":"Jon Snow",
+                 "weapon":[
+                    {"action":"has", "name":"Longclaw"}
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:14:12",
+           "sceneEnd":"0:15:35",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {
+                 "name":"Jon Snow",
+                 "weapon":[
+                    {"action":"has", "name":"Longclaw"}
+                 ]
+              },
+              {"name":"Pypar"},
+              {"name":"Samwell Tarly"},
+              {"name":"Grenn"},
+              {"name":"Rast"}
+           ]
+        },
+        {
+           "sceneStart":"0:15:35",
+           "sceneEnd":"0:15:49",
+           "location":"The Riverlands",
+           "subLocation":"The Twins",
+           "characters":[
+              {"name":"Catelyn Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:15:49",
+           "sceneEnd":"0:17:31",
+           "location":"The Riverlands",
+           "subLocation":"The Twins",
+           "characters":[
+              {"name":"Robb Stark"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Catelyn Stark"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Greatjon Umber"}
+           ]
+        },
+        {
+           "sceneStart":"0:17:31",
+           "sceneEnd":"0:17:58",
+           "location":"The Riverlands",
+           "subLocation":"The Twins",
+           "characters":[
+           ]
+        },
+        {
+           "sceneStart":"0:17:58",
+           "sceneEnd":"0:21:38",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Maester Aemon"}
+           ]
+        },
+        {
+           "sceneStart":"0:21:38",
+           "sceneEnd":"0:23:19",
+           "location":"The Red Waste",
+           "subLocation":"The Desert",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Khal Drogo", "title":"Khal"},
+              {"name":"Qotho"},
+              {"name":"Rakharo"}
+           ]
+        },
+        {
+           "sceneStart":"0:23:19",
+           "sceneEnd":"0:25:07",
+           "location":"The Riverlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {"name":"Tywin Lannister"},
+              {"name":"Tyrion Lannister"},
+              {"name":"Kevan Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:25:07",
+           "sceneEnd":"0:27:41",
+           "location":"The Riverlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {
+                 "name":"Tyrion Lannister",
+                 "sex":{
+                    "with":["Shae"],
+                    "when":"present",
+                    "type":"paid"
+                 }
+              },
+              {"name":"Bronn"},
+              {
+                 "name":"Shae",
+                 "sex":{
+                    "with":["Tyrion Lannister"],
+                    "when":"present",
+                    "type":"paid"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:27:41",
+           "sceneEnd":"0:35:26",
+           "location":"The Red Waste",
+           "characters":[
+              {"name":"Khal Drogo", "title":"Khal"},
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Jorah Mormont"},
+              {"name":"Doreah"},
+              {"name":"Mirri Maz Duur"},
+              {
+                 "name":"Qotho",
+                 "alive":false,
+                 "mannerOfDeath":"Face stab",
+                 "killedBy":[
+                    "Jorah Mormont"
+                 ]
+              },
+              {"name":"Irri"},
+              {"name":"Rakharo"}
+           ]
+        },
+        {
+           "sceneStart":"0:35:26",
+           "sceneEnd":"0:42:44",
+           "location":"The Riverlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {
+                 "name":"Tyrion Lannister",
+                 "sex":{
+                    "with":["Shae"],
+                    "when":"future",
+                    "type":"paid"
+                 }
+              },
+              {
+                 "name":"Shae",
+                 "sex":{
+                    "with":["Tyrion Lannister"],
+                    "when":"future",
+                    "type":"paid"
+                 }
+              },
+              {"name":"Bronn"}
+           ]
+        },
+        {
+           "sceneStart":"0:42:44",
+           "sceneEnd":"0:43:40",
+           "location":"The Riverlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Shae"},
+              {"name":"Bronn"}
+           ]
+        },
+        {
+           "sceneStart":"0:43:40",
+           "sceneEnd":"0:44:04",
+           "location":"The Riverlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Bronn"}
+           ]
+        },
+        {
+           "sceneStart":"0:44:04",
+           "sceneEnd":"0:44:52",
+           "location":"The Riverlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Bronn"},
+              {"name":"Timett"},
+              {"name":"Chella"},
+              {"name":"Shagga"}
+           ]
+        },
+        {
+           "sceneStart":"0:44:52",
+           "sceneEnd":"0:46:31",
+           "location":"The Riverlands",
+           "subLocation":"Battlefield",
+           "characters":[
+              {"name":"Tyrion Lannister"},
+              {"name":"Bronn"},
+              {"name":"Tywin Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:46:31",
+           "sceneEnd":"0:46:52",
+           "location":"The Riverlands",
+           "subLocation":"Riverrun",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Rodrik Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:46:52",
+           "sceneEnd":"0:47:23",
+           "location":"The Riverlands",
+           "subLocation":"Riverrun",
+           "characters":[
+              {"name":"Robb Stark"},
+              {"name":"Catelyn Stark"},
+              {"name":"Rodrik Cassel"}
+           ]
+        },
+        {
+           "sceneStart":"0:47:23",
+           "sceneEnd":"0:49:26",
+           "location":"The Riverlands",
+           "subLocation":"Riverrun",
+           "characters":[
+              {"name":"Jaime Lannister"},
+              {"name":"Robb Stark"},
+              {"name":"Catelyn Stark"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Greatjon Umber"}
+           ]
+        },
+        {
+           "sceneStart":"0:49:26",
+           "sceneEnd":"0:50:24",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Arya Stark",
+                 "weapon":[
+                    {"action":"has", "name":"Needle"}
+                 ]
+              },
+              {"name":"King's Landing Baker"},
+              {"name":"Street Urchin"}
+           ]
+        },
+        {
+           "sceneStart":"0:50:24",
+           "sceneEnd":"0:55:54",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Arya Stark",
+                 "weapon":[
+                    {"action":"has", "name":"Needle"}
+                 ]
+              },
+              {
+                 "name":"Eddard Stark",
+                 "title":"Hand",
+                 "alive":false,
+                 "mannerOfDeath":"Decapitation",
+                 "killedBy":[
+                    "Ilyn Payne"
+                 ]
+              },
+              {"name":"Yoren"},
+              {"name":"Sansa Stark"},
+              {"name":"Petyr Baelish"},
+              {"name":"Cersei Lannister"},
+              {"name":"Joffrey Baratheon", "title":"King"},
+              {"name":"Grand Maester Pycelle"},
+              {"name":"Lord Varys"},
+              {"name":"Sandor Clegane"},
+              {
+                 "name":"Ilyn Payne",
+                 "weapon":[
+                    {"action":"has", "name":"Ice"}
+                 ]
+              }
+           ]
+        }
+     ]
+  },
+  {
+     "seasonNum":1,
+     "episodeNum":10,
+     "episodeTitle":"Fire and Blood",
+     "episodeLink":"/title/tt1851397/",
+     "episodeAirDate":"2011-06-19",
+     "episodeDescription":"With Ned dead, Robb vows to get revenge on the Lannisters. Jon must officially decide if his place is with Robb or the Night's Watch. Daenerys says her final goodbye to Drogo.",
+     "openingSequenceLocations":[
+        "King's Landing",
+        "Winterfell",
+        "The Wall",
+        "Vaes Dothrak"
+     ],
+     "scenes":[
+        {
+           "sceneStart":"0:02:17",
+           "sceneEnd":"0:03:03",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Sandor Clegane"},
+              {
+                 "name":"Ilyn Payne",
+                 "weapon":[
+                    {"action":"has", "name":"Ice"}
+                 ]
+              },
+              {"name":"Eddard Stark", "alive":false},
+              {"name":"Arya Stark"},
+              {"name":"Yoren"},
+              {"name":"Sansa Stark"},
+              {"name":"Lord Varys"}
+           ]
+        },
+        {
+           "sceneStart":"0:03:03",
+           "sceneEnd":"0:03:25",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Arya Stark"},
+              {"name":"Yoren"}
+           ]
+        },
+        {
+           "sceneStart":"0:03:25",
+           "sceneEnd":"0:03:53",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "greensight":true,
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Three-Eyed Raven"}
+           ]
+        },
+        {
+           "sceneStart":"0:03:53",
+           "sceneEnd":"0:04:24",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Osha"},
+              {"name":"Hodor"}
+           ]
+        },
+        {
+           "sceneStart":"0:04:24",
+           "sceneEnd":"0:05:40",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Osha"},
+              {"name":"Shaggydog"},
+              {"name":"Rickon Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:05:40",
+           "sceneEnd":"0:06:07",
+           "location":"The North",
+           "subLocation":"Winterfell",
+           "characters":[
+              {"name":"Bran Stark"},
+              {"name":"Osha"},
+              {"name":"Maester Luwin"}
+           ]
+        },
+        {
+           "sceneStart":"0:06:07",
+           "sceneEnd":"0:08:07",
+           "location":"The Riverlands",
+           "subLocation":"Camp of the North",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Robb Stark"}
+           ]
+        },
+        {
+           "sceneStart":"0:08:07",
+           "sceneEnd":"0:10:52",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Marillion"},
+              {"name":"Sansa Stark"},
+              {"name":"Cersei Lannister"},
+              {"name":"Joffrey Baratheon", "title":"King"},
+              {"name":"Sandor Clegane"},
+              {
+                 "name":"Ilyn Payne",
+                 "weapon":[
+                    {"action":"has", "name":"Ice"}
+                 ]
+              },
+              {"name":"Meryn Trant"}
+           ]
+        },
+        {
+           "sceneStart":"0:10:52",
+           "sceneEnd":"0:13:32",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Joffrey Baratheon", "title":"King"},
+              {"name":"Sandor Clegane"},
+              {"name":"Sansa Stark"},
+              {"name":"Meryn Trant"},
+              {"name":"Eddard Stark", "alive":false},
+              {
+                 "name":"Septa Mordane",
+                 "alive":false,
+                 "mannerOfDeath":"Decapitation"
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:13:32",
+           "sceneEnd":"0:15:48",
+           "location":"The Riverlands",
+           "subLocation":"Camp of the North",
+           "characters":[
+              {"name":"Robb Stark", "title":"King"},
+              {"name":"Catelyn Stark"},
+              {"name":"Rodrik Cassel"},
+              {"name":"Theon Greyjoy"},
+              {"name":"Greatjon Umber"},
+              {"name":"Rickard Karstark"},
+              {"name":"Jonos Bracken"}
+           ]
+        },
+        {
+           "sceneStart":"0:15:48",
+           "sceneEnd":"0:18:51",
+           "location":"The Riverlands",
+           "subLocation":"Camp of the North",
+           "characters":[
+              {"name":"Catelyn Stark"},
+              {"name":"Jaime Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:18:51",
+           "sceneEnd":"0:19:23",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Cersei Lannister",
+                 "sex":{
+                    "with":["Lancel Lannister"],
+                    "when":"past",
+                    "type":"incest"
+                 }
+              },
+              {
+                 "name":"Lancel Lannister",
+                 "sex":{
+                    "with":["Cersei Lannister"],
+                    "when":"past",
+                    "type":"incest"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:19:23",
+           "sceneEnd":"0:20:39",
+           "location":"The Riverlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {"name":"Tywin Lannister"},
+              {"name":"Kevan Lannister"},
+              {"name":"Tyrion Lannister"},
+              {"name":"Leo Lefford"},
+              {"name":"Addam Marbrand"}
+           ]
+        },
+        {
+           "sceneStart":"0:20:39",
+           "sceneEnd":"0:22:37",
+           "location":"The Riverlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {"name":"Tywin Lannister"},
+              {"name":"Tyrion Lannister"}
+           ]
+        },
+        {
+           "sceneStart":"0:22:37",
+           "sceneEnd":"0:24:30",
+           "location":"The Red Waste",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Jorah Mormont"},
+              {
+                 "name":"Rhaego",
+                 "alive":false,
+                 "mannerOfDeath":"Malformed Birth"
+              },
+              {"name":"Mirri Maz Duur"}
+           ]
+        },
+        {
+           "sceneStart":"0:24:30",
+           "sceneEnd":"0:26:07",
+           "location":"The Red Waste",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Jorah Mormont"},
+              {"name":"Mirri Maz Duur"},
+              {"name":"Rakharo"},
+              {"name":"Irri"},
+              {"name":"Khal Drogo", "title":"Khal"}
+           ]
+        },
+        {
+           "sceneStart":"0:26:07",
+           "sceneEnd":"0:27:31",
+           "location":"The Red Waste",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Mirri Maz Duur"}
+           ]
+        },
+        {
+           "sceneStart":"0:27:31",
+           "sceneEnd":"0:28:28",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jon Snow"},
+              {"name":"Samwell Tarly"},
+              {"name":"Ghost"}
+           ]
+        },
+        {
+           "sceneStart":"0:28:28",
+           "sceneEnd":"0:29:52",
+           "location":"The Riverlands",
+           "subLocation":"Lannister Camp",
+           "characters":[
+              {
+                 "name":"Shae",
+                 "sex":{
+                    "with":["Tyrion Lannister"],
+                    "when":"future",
+                    "type":"paid"
+                 }
+              },
+              {
+                 "name":"Tyrion Lannister",
+                 "sex":{
+                    "with":["Shae"],
+                    "when":"future",
+                    "type":"paid"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:29:52",
+           "sceneEnd":"0:31:55",
+           "location":"The North",
+           "subLocation":"The Gift",
+           "characters":[
+              {
+                 "name":"Jon Snow",
+                 "weapon":[
+                    {"action":"has", "name":"Longclaw"}
+                 ]
+              },
+              {"name":"Ghost"},
+              {"name":"Pypar"},
+              {"name":"Samwell Tarly"},
+              {"name":"Grenn"}
+           ]
+        },
+        {
+           "sceneStart":"0:31:55",
+           "sceneEnd":"0:33:02",
+           "location":"The Red Waste",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Khal Drogo", "title":"Khal"}
+           ]
+        },
+        {
+           "sceneStart":"0:33:02",
+           "sceneEnd":"0:34:28",
+           "location":"The Red Waste",
+           "characters":[
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {
+                 "name":"Khal Drogo",
+                 "title":"Khal",
+                 "alive":false,
+                 "mannerOfDeath":"Suffocation",
+                 "killedBy":[
+                    "Daenerys Targaryen"
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:34:28",
+           "sceneEnd":"0:37:33",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Grand Maester Pycelle",
+                 "sex":{
+                    "with":["Ros"],
+                    "when":"past",
+                    "type":"paid"
+                 }
+              },
+              {
+                 "name":"Ros",
+                 "sex":{
+                    "with":["Grand Maester Pycelle"],
+                    "when":"past",
+                    "type":"paid"
+                 }
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:37:33",
+           "sceneEnd":"0:37:52",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Grand Maester Pycelle"}
+           ]
+        },
+        {
+           "sceneStart":"0:37:52",
+           "sceneEnd":"0:39:58",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Petyr Baelish"},
+              {"name":"Lord Varys"},
+              {"name":"Joffrey Baratheon", "title":"King"}
+           ]
+        },
+        {
+           "sceneStart":"0:39:58",
+           "sceneEnd":"0:40:38",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Yoren"},
+              {
+                 "name":"Arya Stark",
+                 "weapon":[
+                    {"action":"has", "name":"Needle"}
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:40:38",
+           "sceneEnd":"0:40:48",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {"name":"Yoren"},
+              {
+                 "name":"Arya Stark",
+                 "weapon":[
+                    {"action":"has", "name":"Needle"}
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:40:48",
+           "sceneEnd":"0:43:03",
+           "location":"The Crownlands",
+           "subLocation":"King's Landing",
+           "characters":[
+              {
+                 "name":"Arya Stark",
+                 "weapon":[
+                    {"action":"has", "name":"Needle"}
+                 ]
+              },
+              {"name":"Hot Pie"},
+              {"name":"Lommy Greenhands"},
+              {"name":"Gendry"},
+              {"name":"Yoren"}
+           ]
+        },
+        {
+           "sceneStart":"0:43:03",
+           "sceneEnd":"0:45:00",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jeor Mormont"},
+              {"name":"Jon Snow"}
+           ]
+        },
+        {
+           "sceneStart":"0:45:00",
+           "sceneEnd":"0:45:46",
+           "location":"The Wall",
+           "subLocation":"Castle Black",
+           "characters":[
+              {"name":"Jeor Mormont"},
+              {
+                 "name":"Jon Snow",
+                 "weapon":[
+                    {"action":"has", "name":"Longclaw"}
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:45:46",
+           "sceneEnd":"0:50:09",
+           "location":"The Red Waste",
+           "characters":[
+              {"name":"Khal Drogo", "title":"Khal", "alive":false},
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Rakharo"},
+              {"name":"Drogon", "born":false},
+              {"name":"Rhaegal", "born":false},
+              {"name":"Viserion", "born":false},
+              {"name":"Jorah Mormont"},
+              {
+                 "name":"Mirri Maz Duur",
+                 "alive":false,
+                 "mannerOfDeath":"Burning",
+                 "killedBy":[
+                    "Daenerys Targaryen"
+                 ]
+              }
+           ]
+        },
+        {
+           "sceneStart":"0:50:09",
+           "sceneEnd":"0:51:57",
+           "location":"The Red Waste",
+           "characters":[
+              {"name":"Jorah Mormont"},
+              {"name":"Rakharo"},
+              {"name":"Daenerys Targaryen", "title":"Khaleesi"},
+              {"name":"Drogon"},
+              {"name":"Rhaegal"},
+              {"name":"Viserion"}
+           ]
+        }
+     ]
+  }
+];
+
+const houses = [
+  {
+    "name":"Stark",
+    "characters":[
+      "Arya Stark",
+      "Benjen Stark",
+      "Bran Stark",
+      "Catelyn Stark",
+      "Eddard Stark",
+      "Ghost",
+      "Grey Wind",
+      "Jon Snow",
+      "Lady",
+      "Nymeria",
+      "Rickon Stark",
+      "Robb Stark",
+      "Sansa Stark",
+      "Shaggydog",
+      "Summer"
+    ]
+  },
+  {
+    "name":"Targaryen",
+    "characters":[
+      "Daenerys Targaryen",
+      "Drogon",
+      "Rhaegal",
+      "Viserion",
+      "Viserys Targaryen"
+    ]
+  },
+  {
+    "name":"Baratheon",
+    "characters":[
+      "Joffrey Baratheon",
+      "Myrcella Baratheon",
+      "Renly Baratheon",
+      "Robert Baratheon",
+      "Selyse Baratheon",
+      "Shireen Baratheon",
+      "Stannis Baratheon",
+      "Tommen Baratheon"
+    ]
+  },
+  {
+    "name":"Lannister",
+    "characters":[
+      "Cersei Lannister",
+      "Jaime Lannister",
+      "Kevan Lannister",
+      "Lancel Lannister",
+      "Tyrion Lannister",
+      "Tywin Lannister"
+    ]
+  },
+  {
+    "name":"Greyjoy",
+    "characters":[
+      "Balon Greyjoy",
+      "Euron Greyjoy",
+      "Theon Greyjoy",
+      "Yara Greyjoy"
+    ]
+  },
+  {
+    "name":"Tyrell",
+    "characters":[
+      "Loras Tyrell",
+      "Mace Tyrell",
+      "Margaery Tyrell",
+      "Olenna Tyrell"
+    ]
+  },
+  {
+    "name":"Martell",
+    "characters":[
+      "Doran Martell",
+      "Ellaria Sand",
+      "Nymeria Sand",
+      "Obara Sand",
+      "Oberyn Martell",
+      "Trystane Martell",
+      "Tyene Sand"
+    ]
+  },
+  {
+    "name":"Frey",
+    "characters":[
+      "Black Walder Rivers",
+      "Lothar Frey",
+      "Walder Frey"
+    ]
+  },
+  {
+    "name":"Tully",
+    "characters":[
+      "Brynden Tully",
+      "Edmure Tully"
+    ]
+  }
+];
+
+module.exports = {
+  s1episodes,
+  houses
+}


### PR DESCRIPTION
I added two Game of Thrones datasets. The first dataset is an array of objects representing each episode in season 1 (I could add more but season 1 is pretty big). These objects contain the keys seasonNum, episodeNum, episodeTitle, episodeAirDate, episodeDescription, openingSequenceLocations, and scenes. The second dataset is an array of objects representing each of the powerful houses in Game of Thrones.

Some ideas of what to do with these datasets:

- Are there any innocent nobles left? Find out which nobles haven't seen anyone die.
- Tally up all the deaths by house
- Find all the scenes where there are 2 characters from different houses
- Find all the scenes where there is a character from a house and someone dies
- Tally up which character from all the major houses has seen the most deaths


