### PR TITLE
Jacob Bogart's dataset - Chicago gay bars & local drag queens

### DIFF
--- a/mod-2/whateverly/1901/jacobogart.js
+++ b/mod-2/whateverly/1901/jacobogart.js
@@ -1,1013 +1,1050 @@
 const bars = [
   {
-    "name": "Roscoe's Tavern",
     "address": "3356 N Halsted St, Chicago, IL 60657",
-    "phone": "(773) 281-3355",
-    "website": "https://roscoes.com/",
     "facebook": "https://www.facebook.com/RoscoesTavern",
+    "id": 1000,
+    "imageURL": "https://scontent-dfw5-1.cdninstagram.com/vp/f5f0ec968d925b64e11de63f19841e9b/5D4D67F2/t51.2885-19/11910058_1635849420031804_1752015214_a.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/roscoestavern/",
+    "name": "Roscoe's Tavern",
+    "phone": "(773) 281-3355",
+    "shows": [{
+      "category": "competition",
+      "dayOfWeek": "Tuesday",
+      "frequency": "weekly",
+      "id": 1001,
+      "reoccuring": true,
+      "startTime": 2300,
+      "title": "Roscoe's Drag Race"
+    }, {
+      "category": "viewing party",
+      "dayOfWeek": "Thursday",
+      "frequency": "weekly",
+      "host": "T Rex",
+      "id": 1002,
+      "notes": "Doors open at 5PM. Seating begins at 6PM. New episode begins at 8PM. No Cover!",
+      "reoccuring": true,
+      "startTime": 2000,
+      "title": "Roscoe’s RPDR S11 Viewing Party"
+    }, {
+      "category": "drag show",
+      "dayOfWeek": "Sunday",
+      "frequency": "monthly",
+      "host": "T Rex",
+      "id": 1003,
+      "lineups": {
+        "04/07/19": ["Bambi Banks Couleé", "Denali", "Ashley Malone", "Kat Sass", "Keri Traid", "Tenderoni"]
+      },
+      "notes": "Bringing Generations X, Y, & Z together to celebrate their shared love of the music from the mid 1990’s through the early 2000’s with DJ Ron!",
+      "reoccuring": true,
+      "startTime": 2100,
+      "title": "XYZ"
+    }],
     "twitter": "https://twitter.com/Roscoestavern",
-    "shows": [
-      {
-        "title": "Roscoe's Drag Race",
-        "category": "competition",
-        "dayOfWeek": "Tuesday",
-        "reoccuring": true,
-        "frequency": "weekly"
-      },
-      {
-        "title": "Roscoe’s RPDR S11 Viewing Party",
-        "category": "viewing party",
-        "dayOfWeek": "Thursday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "host": "T Rex",
-        "notes": "Doors open at 5PM. Seating begins at 6PM. New episode begins at 8PM. No Cover!"
-      },
-      {
-        "title": "XYZ",
-        "category": "drag show",
-        "dayOfWeek": "Sunday",
-        "reoccuring": true,
-        "frequency": "monthly",
-        "host": "T Rex",
-        "lineups": {
-          "04/07/19": [
-            "Bambi Banks Couleé",
-            "Denali",
-            "Ashley Malone",
-            "Kat Sass",
-            "Keri Traid",
-            "Tenderoni"
-          ]
-        },
-        "notes": "Bringing Generations X, Y, & Z together to celebrate their shared love of the music from the mid 1990’s through the early 2000’s with DJ Ron!"
-      }
-    ]
-  },
-  {
-    "name": "Berlin Nightclub",
+    "website": "https://roscoes.com/"
+  }, {
     "address": "954 W Belmont Ave, Chicago, IL 60657",
-    "phone": "(773) 348-4975",
-    "website": "https://berlinchicago.com/",
     "facebook": "https://www.facebook.com/BerlinNightclub/",
+    "id": 1100,
+    "imageURL": "https://scontent-dfw5-1.cdninstagram.com/vp/69f8d123d37ce635fa5c7d3d1890c0a3/5D29B4BA/t51.2885-19/11429780_1684878531735729_1689801400_a.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/berlinnightclub/",
+    "name": "Berlin Nightclub",
+    "phone": "(773) 348-4975",
+    "shows": [{
+      "category": "drag show",
+      "dayOfWeek": "Monday",
+      "frequency": "1st Monday",
+      "id": 1101,
+      "lineups": {
+        "04/01/19": ["Alex Kay", "Blondebenét", "Logan Zass", "Joonage À Trois"]
+      },
+      "notes": "3 Year Anniversary! Join us for a Small Tribute to the Memories we've made Throughout the Years",
+      "reoccuring": true,
+      "startTime": 2200,
+      "title": "Squad Goals"
+    }, {
+      "category": "competition",
+      "dayOfWeek": "Wednesday",
+      "frequency": null,
+      "id": 1102,
+      "lineups": {
+        "04/03/19": ["Lady Ivory", "Claire Voyant", "Kat Sass", "Tenderoni", "Masha Potato", "Siichele"]
+      },
+      "reoccuring": false,
+      "startTime": 2200,
+      "title": "SLAY: Afterbirth"
+    }, {
+      "category": "drag show",
+      "dayOfWeek": "Saturday",
+      "frequency": "weekly",
+      "host": "T Rex",
+      "id": 1103,
+      "lineups": {
+        "04/06/19": ["Laila McQueen", "Sasha Belle", "Chasity Marie", "Lucy Stoole", "Aunty Chan", "Savannah Westbrooke", "Aura Mayari"],
+        "04/13/19": ["Ophelia Belle", "Monica Beverly Hillz", "Imp Queen", "Denali", "Irregular Girl", "Tiffany Diamond", "Raven Samore"],
+        "04/20/19": ["Jasmine Masters", "The Princess", "Julia Starr", "Tracey Ottomey", "Cleo Pockalipps", "Kahmora Hall", "Ashley Malone"],
+        "04/27/19": ["Serena Cha Cha", "Gilda Wabbit", "Umi Naughty", "Zsa Zsa Gabortion", "Khloe Park", "Bambi Banks Couleé", "Elektra Del Rio"]
+      },
+      "reoccuring": true,
+      "startTime": 2230,
+      "title": "Drag Matinee"
+    }, {
+      "category": "drag show",
+      "dayOfWeek": "Monday",
+      "frequency": "3rd Monday",
+      "host": "T Rex",
+      "id": 1104,
+      "lineups": {
+        "04/15/19": []
+      },
+      "notes": "THE HALF-TIME SHOW: Surprises, Reveals, and OMG Moments! Bring the Drama and Snatch the Gig!",
+      "reoccuring": true,
+      "startTime": 2230,
+      "title": "Plot Twist"
+    }, {
+      "category": "competition",
+      "dayOfWeek": "Monday",
+      "frequency": "2nd and 4th Mondays",
+      "host": ["T Rex", "Nico"],
+      "id": 1105,
+      "notes": "A 3 Round Competition for Drag Queens, Bio Queens, Kings, and Straight Up Aliens",
+      "reoccuring": true,
+      "startTime": 2200,
+      "title": "Crash Landing"
+    }],
     "twitter": "https://twitter.com/BerlinNightclub",
-    "shows": [
-      {
-        "title": "Squad Goals",
-        "category": "drag show",
-        "dayOfWeek": "Monday",
-        "reoccuring": true,
-        "frequency": "1st Monday",
-        "startTime": 2200,
-        "lineups": {
-          "04/01/19": [
-            "Alex Kay",
-            "Blondebenét",
-            "Logan Zass",
-            "Joonage À Trois"
-          ]
-        },
-        "notes": "3 Year Anniversary! Join us for a Small Tribute to the Memories we've made Throughout the Years"
-      },
-      {
-        "title": "SLAY: Afterbirth",
-        "category": "competition",
-        "dayOfWeek": "Wednesday",
-        "reoccuring": false,
-        "frequency": null,
-        "startTime": 2200,
-        "lineups": {
-          "04/03/19": [
-            "Lady Ivory",
-            "Claire Voyant",
-            "Kat Sass",
-            "Tenderoni",
-            "Masha Potato",
-            "Siichele"
-          ]
-        }
-      },
-      {
-        "title": "Drag Matinee",
-        "category": "drag show",
-        "dayOfWeek": "Saturday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2230,
-        "host": "T Rex",
-        "lineups": {
-          "04/06/19": [
-            "Laila McQueen",
-            "Sasha Belle",
-            "Chasity Marie",
-            "Lucy Stoole",
-            "Aunty Chan",
-            "Savannah Westbrooke",
-            "Aura Mayari"
-          ],
-          "04/13/19": [
-            "Ophelia Belle",
-            "Monica Beverly Hillz",
-            "Imp Queen",
-            "Denali",
-            "Irregular Girl",
-            "Tiffany Diamond",
-            "Raven Samore"
-          ],
-          "04/20/19": [
-            "Jasmine Masters",
-            "The Princess",
-            "Julia Starr",
-            "Tracey Ottomey",
-            "Cleo Pockalipps",
-            "Kahmora Hall",
-            "Ashley Malone"
-          ],
-          "04/27/19": [
-            "Serena Cha Cha",
-            "Gilda Wabbit",
-            "Umi Naughty",
-            "Zsa Zsa Gabortion",
-            "Khloe Park",
-            "Bambi Banks Couleé",
-            "Elektra Del Rio"
-          ]
-        }
-      },
-      {
-        "title": "Plot Twist",
-        "category": "drag show",
-        "dayOfWeek": "Monday",
-        "reoccuring": true,
-        "frequency": "3rd Mondau",
-        "startTime": 2230,
-        "host": "T Rex",
-        "lineups": {
-          "04/15/19": []
-        },
-        "notes": "THE HALF-TIME SHOW: Surprises, Reveals, and OMG Moments! Bring the Drama and Snatch the Gig!"
-      },
-      {
-        "title": "Crash Landing",
-        "category": "competition",
-        "dayOfWeek": "Monday",
-        "reoccuring": true,
-        "frequency": "2nd and 4th Mondays",
-        "startTime": 2200,
-        "host": [
-          "T Rex",
-          "Nico"
-        ],
-        "notes": "A 3 Round Competition for Drag Queens, Bio Queens, Kings, and Straight Up Aliens"
-      }
-    ]
-  },
-  {
-    "name": "Sidetrack The Video Bar",
+    "website": "https://berlinchicago.com/"
+  }, {
     "address": "3349 N Halsted St Chicago, IL  60657",
-    "phone": "(773) 477-9189",
-    "website": "https://www.sidetrackchicago.com/",
     "facebook": "https://www.facebook.com/SidetrackBar",
+    "id": 1200,
+    "imageURL": "https://scontent-dfw5-1.cdninstagram.com/vp/0d7a3e2ede7a72ecea3ca195b2c1ff62/5D47963B/t51.2885-19/s320x320/53637298_2655474464523437_1228221987931815936_n.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/sidetrackbar/",
+    "name": "Sidetrack The Video Bar",
+    "phone": "(773) 477-9189",
+    "shows": [{
+      "category": "viewing party",
+      "dayOfWeek": "Thursday",
+      "frequency": "weekly",
+      "host": ["Dixie Lynn Cartwright", "DiDa Ritz"],
+      "id": 1201,
+      "reoccuring": true,
+      "startTime": 2000,
+      "title": "Chicago's RuPaul's Drag Race Season 11 Viewing Party"
+    }, {
+      "category": "competition",
+      "dayOfWeek": "Thursday",
+      "frequency": "weekly",
+      "host": ["Dixie Lynn Cartwright", "Danika Bone't"],
+      "id": 1202,
+      "reoccuring": true,
+      "startTime": 2200,
+      "title": "Shantay You Stay!"
+    }, {
+      "category": "competition",
+      "dayOfWeek": "Tuesday",
+      "frequency": "last",
+      "host": ["Dixie Lynn Cartwright", "Alexis Bevels"],
+      "id": 1203,
+      "notes": "You are the judge for who wins (well, Dixie says she's the winner, but we'll see about that) so join us to cheer on your faves.",
+      "reoccuring": true,
+      "startTime": 2130,
+      "title": "Dixie Wins A Talent Show"
+    }],
     "twitter": "https://twitter.com/sidetrackbar",
-    "shows": [
-      {
-        "title": "Chicago's RuPaul's Drag Race Season 11 Viewing Party",
-        "category": "viewing party",
-        "dayOfWeek": "Thursday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2000,
-        "host": [
-          "Dixie Lynn Cartwright",
-          "DiDa Ritz"
-        ]
-      },
-      {
-        "title": "Shantay You Stay!",
-        "category": "competition",
-        "dayOfWeek": "Thursday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2200,
-        "host": [
-          "Dixie Lynn Cartwright",
-          "Danika Bone't"
-        ]
-      },
-      {
-        "title": "Dixie Wins A Talent Show",
-        "category": "competition",
-        "dayOfWeek": "Tuesday",
-        "reoccuring": true,
-        "frequency": "last",
-        "startTime": 2130,
-        "host": [
-          "Dixie Lynn Cartwright",
-          "Alexis Bevels"
-        ],
-        "notes": "You are the judge for who wins (well, Dixie says she's the winner, but we'll see about that) so join us to cheer on your faves."
-      }
-    ]
-  },
-  {
-    "name": "Scarlet Bar",
+    "website": "https://www.sidetrackchicago.com/"
+  }, {
     "address": "3320 N Halsted St, Chicago, IL 60657",
-    "phone": "(773) 348-1053",
-    "website": "https://www.scarletchicago.com/",
     "facebook": "https://www.facebook.com/Scarletbar/",
+    "id": 1300,
+    "imageURL": "https://scontent-dfw5-1.cdninstagram.com/vp/3fe6c874c89af61ae9dc27221683200b/5D468A54/t51.2885-19/s320x320/47694986_605876646513728_5088531554125217792_n.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/scarletchicago/",
+    "name": "Scarlet Bar",
+    "phone": "(773) 348-1053",
+    "shows": [{
+      "category": "drag show",
+      "dayOfWeek": "Wednesday",
+      "facebookEvent": "https://www.facebook.com/events/2347284362197354/",
+      "frequency": null,
+      "host": ["Abhijeet", "Irregular Girl"],
+      "id": 1301,
+      "notes": "Starting at 8:30pm we will be playing /“Mary Poppins Returns/” and afterwards the SingAlong event will begin! Also, at the don’t miss our new Disney themed Drag Show!",
+      "reoccuring": false,
+      "startTime": 2000,
+      "title": "SingAlong! “Mary Poppins Returns” Viewing Party!"
+    }, {
+      "category": "dance party",
+      "dayOfWeek": "Friday",
+      "frequency": "weekly",
+      "host": "Kenzie Coulee",
+      "id": 1302,
+      "reoccuring": true,
+      "startTime": 2300,
+      "title": "Friday's with Kenzie Coulee"
+    }, {
+      "category": "dance party",
+      "dayOfWeek": "Thursday",
+      "frequency": "weekly",
+      "host": "Khloe Park",
+      "id": 1303,
+      "reoccuring": true,
+      "startTime": 2200,
+      "title": "Frat Night"
+    }],
     "twitter": "https://twitter.com/scarletchicago",
-    "shows": [
-      {
-        "title": "SingAlong! “Mary Poppins Returns” Viewing Party!",
-        "facebookEvent": "https://www.facebook.com/events/2347284362197354/",
-        "category": "drag show",
-        "dayOfWeek": "Wednesday",
-        "reoccuring": false,
-        "frequency": null,
-        "startTime": 2000,
-        "host": [
-          "Abhijeet",
-          "Irregular Girl"
-        ],
-        "notes": "Starting at 8:30pm we will be playing /“Mary Poppins Returns/” and afterwards the SingAlong event will begin! Also, at the don’t miss our new Disney themed Drag Show!"
-      },
-      {
-        "title": "Friday's with Kenzie Coulee",
-        "category": "dance party",
-        "dayOfWeek": "Friday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2300,
-        "host": "Kenzie Coulee"
-      },
-      {
-        "title": "Frat Night",
-        "category": "dance party",
-        "dayOfWeek": "Thursday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2200,
-        "host": "Khloe Park"
-      }
-    ]
-  },
-  {
-    "name": "Hydrate",
+    "website": "https://www.scarletchicago.com/"
+  }, {
     "address": "3458 N Halsted St, Chicago, IL 60657",
-    "phone": "(773) 975-9244",
-    "website": "http://www.hydratechicago.com/",
     "facebook": "https://www.facebook.com/hydratechicago/",
+    "id": 1400,
+    "imageURL": "https://scontent-dfw5-1.cdninstagram.com/vp/c858de066286f2ee5ea8f26606029098/5D4DAB04/t51.2885-19/s320x320/35277768_2051636375049620_718857438064803840_n.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/hydrate.nightclub/",
+    "name": "Hydrate",
+    "phone": "(773) 975-9244",
+    "shows": [{
+      "category": "drag show",
+      "dayOfWeek": "Monday",
+      "frequency": "weekly",
+      "host": "Mz. Ruff ‘N Stuff",
+      "id": 1401,
+      "notes": "Monday nights get an upgrade with a show unlike any you’ve seen before!",
+      "reoccuring": true,
+      "startTime": 2300,
+      "title": "Ruffy’s Lipstick & Mascara"
+    }, {
+      "category": "drag show",
+      "dayOfWeek": "Wednesday",
+      "frequency": "weekly",
+      "host": ["Mz. Ruff ‘N Stuff", "Mimi Marks"],
+      "id": 1402,
+      "notes": "With weekly guest performers!",
+      "reoccuring": true,
+      "startTime": 2300,
+      "title": "Honeys on Halsted"
+    }, {
+      "category": "drag show",
+      "dayOfWeek": ["Friday", "Saturday"],
+      "frequency": "semi-weekly",
+      "host": ["Naysha Lopez", "Mz. Ruff ‘N Stuff"],
+      "id": 1403,
+      "notes": "With weekly guest performers!",
+      "reoccuring": true,
+      "startTime": 2115,
+      "title": "Beauties & Beaus",
+      "website": "http://beautiesandbeaus.com/"
+    }],
     "twitter": "https://twitter.com/HydrateChicago",
-    "shows": [
-      {
-        "title": "Ruffy’s Lipstick & Mascara",
-        "category": "drag show",
-        "dayOfWeek": "Monday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2300,
-        "host": "Mz. Ruff ‘N Stuff",
-        "notes": "Monday nights get an upgrade with a show unlike any you’ve seen before!"
-      },
-      {
-        "title": "Honeys on Halsted",
-        "category": "drag show",
-        "dayOfWeek": "Wednesday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2300,
-        "host": [
-          "Mz. Ruff ‘N Stuff",
-          "Mimi Marks"
-        ],
-        "notes": "With weekly guest performers!"
-      },
-      {
-        "title": "Beauties & Beaus",
-        "website": "http://beautiesandbeaus.com/",
-        "category": "drag show",
-        "dayOfWeek": [
-          "Friday",
-          "Saturday"
-        ],
-        "reoccuring": true,
-        "frequency": "semi-weekly",
-        "startTime": 2115,
-        "host": [
-          "Naysha Lopez",
-          "Mz. Ruff ‘N Stuff"
-        ],
-        "notes": "With weekly guest performers!"
-      }
-    ]
-  },
-  {
-    "name": "Hamburger Mary's",
+    "website": "http://www.hydratechicago.com/"
+  }, {
     "address": "5400 N Clark St, Chicago, IL 60640",
-    "phone": "(773) 784-6969",
-    "website": "https://www.hamburgermarys.com/chicago/",
     "facebook": "https://www.facebook.com/maryschicago/",
+    "id": 1500,
+    "imageURL": "https://scontent-dfw5-1.cdninstagram.com/vp/90d88990a816a857bc7344bc252f8d5d/5D3BC2AC/t51.2885-19/s320x320/25010576_640902069634252_8311160960739966976_n.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/maryschicago/",
+    "name": "Hamburger Mary's",
+    "phone": "(773) 784-6969",
+    "shows": [{
+      "category": "bingo",
+      "dayOfWeek": "Monday",
+      "frequency": "weekly",
+      "host": "Granny Mattress",
+      "id": 1501,
+      "notes": "Guests are asked to make a $15 donation to play all night (10 games, three chances to win each game).",
+      "reoccuring": true,
+      "startTime": 2000,
+      "title": "Charity HamBingo Mary’s",
+      "website": "https://www.hamburgermarys.com/chicago/events/event/charity-hambingo-marys/"
+    }, {
+      "category": "competition",
+      "dayOfWeek": "Tuesday",
+      "frequency": "weekly",
+      "host": "Fay Ludes",
+      "id": 1502,
+      "notes": "We start off with 6-8 contestants who compete for the chance to come back the next week. The bi-weekly winner gets a booking at one of Mary’s “Dining with the Divas” shows ",
+      "reoccuring": true,
+      "startTime": 2000,
+      "title": "Let’s Make a DIVA!",
+      "website": "https://www.hamburgermarys.com/chicago/events/event/lets-make-a-diva-2/"
+    }, {
+      "category": "viewing party",
+      "dayOfWeek": "Thrusday",
+      "frequency": "weekly",
+      "host": "Diana Tunnel",
+      "id": 1503,
+      "reoccuring": true,
+      "startTime": 2000,
+      "title": "Drag Race at Mary's"
+    }, {
+      "category": "bingo",
+      "dayOfWeek": "Sunday",
+      "frequency": "weekly",
+      "host": "Alexis Bevels",
+      "id": 1504,
+      "notes": "Guests are asked to make a $15 donation to play all night (10 games, three chances to win each game).",
+      "reoccuring": true,
+      "startTime": 1900,
+      "title": "Charity HamBingo Mary’s",
+      "website": "https://www.hamburgermarys.com/chicago/events/event/charity-hambingo-marys/"
+    }, {
+      "category": "drag show",
+      "dayOfWeek": "Friday",
+      "frequency": "semi-weekly",
+      "id": 1505,
+      "notes": "Seating will begin about a half hour before showtime.  Shows run about an hour.",
+      "reoccuring": true,
+      "startTime": [1930, 2130],
+      "title": "Dining With the Divas! (Friday)",
+      "website": "https://www.hamburgermarys.com/chicago/events/event/dining-with-the-divas-2/"
+    }, {
+      "category": "drag show",
+      "dayOfWeek": "Saturday",
+      "frequency": "semi-weekly",
+      "id": 1506,
+      "notes": "Seating will begin about a half hour before showtime.  Shows run about an hour.",
+      "reoccuring": true,
+      "startTime": [1930, 2130],
+      "title": "Dining With the Divas! (Saturday)",
+      "website": "https://www.hamburgermarys.com/chicago/events/event/dining-with-divas/"
+    }, {
+      "category": "drag show",
+      "dayOfWeek": "Sunday",
+      "frequency": "semi-weekly",
+      "id": 1507,
+      "notes": "Seating begins at 10:15am for the first show and 12:15pm for the second show.",
+      "reoccuring": true,
+      "startTime": [1100, 1300],
+      "title": "Divas Brunch",
+      "website": "https://www.hamburgermarys.com/chicago/events/event/divas-brunch-with-bottomless-mimosas/"
+    }],
     "twitter": "https://twitter.com/MarysChicago?lang=en",
-    "shows": [
-      {
-        "title": "Charity HamBingo Mary’s",
-        "website": "https://www.hamburgermarys.com/chicago/events/event/charity-hambingo-marys/",
-        "category": "bingo",
-        "dayOfWeek": "Monday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2000,
-        "host": "Granny Mattress",
-        "notes": "Guests are asked to make a $15 donation to play all night (10 games, three chances to win each game)."
-      },
-      {
-        "title": "Let’s Make a DIVA!",
-        "website": "https://www.hamburgermarys.com/chicago/events/event/lets-make-a-diva-2/",
-        "category": "competition",
-        "dayOfWeek": "Tuesday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2000,
-        "host": "Fay Ludes",
-        "notes": "We start off with 6-8 contestants who compete for the chance to come back the next week. The bi-weekly winner gets a booking at one of Mary’s “Dining with the Divas” shows "
-      },
-      {
-        "title": "Drag Race at Mary's",
-        "category": "viewing party",
-        "dayOfWeek": "Thrusday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2000,
-        "host": "Diana Tunnel"
-      },
-      {
-        "title": "Charity HamBingo Mary’s",
-        "website": "https://www.hamburgermarys.com/chicago/events/event/charity-hambingo-marys/",
-        "category": "bingo",
-        "dayOfWeek": "Sunday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 1900,
-        "host": "Alexis Bevels",
-        "notes": "Guests are asked to make a $15 donation to play all night (10 games, three chances to win each game)."
-      },
-      {
-        "title": "Dining With the Divas! (Friday)",
-        "website": "https://www.hamburgermarys.com/chicago/events/event/dining-with-the-divas-2/",
-        "category": "drag show",
-        "dayOfWeek": "Friday",
-        "reoccuring": true,
-        "frequency": "semi-weekly",
-        "startTime": [
-          1930,
-          2130
-        ],
-        "notes": "Seating will begin about a half hour before showtime.  Shows run about an hour."
-      },
-      {
-        "title": "Dining With the Divas! (Saturday)",
-        "website": "https://www.hamburgermarys.com/chicago/events/event/dining-with-divas/",
-        "category": "drag show",
-        "dayOfWeek": "Saturday",
-        "reoccuring": true,
-        "frequency": "semi-weekly",
-        "startTime": [
-          1930,
-          2130
-        ],
-        "notes": "Seating will begin about a half hour before showtime.  Shows run about an hour."
-      },
-      {
-        "title": "Divas Brunch",
-        "website": "https://www.hamburgermarys.com/chicago/events/event/divas-brunch-with-bottomless-mimosas/",
-        "category": "drag show",
-        "dayOfWeek": "Sunday",
-        "reoccuring": true,
-        "frequency": "semi-weekly",
-        "startTime": [
-          1100,
-          1300
-        ],
-        "notes": "Seating begins at 10:15am for the first show and 12:15pm for the second show."
-      }
-    ]
-  },
-  {
-    "name": "Kit Kat Lounge & Supper Club",
+    "website": "https://www.hamburgermarys.com/chicago/"
+  }, {
     "address": "3700 N Halsted St, Chicago, IL 60613",
-    "phone": "(773) 525-1111",
-    "website": "http://www.kitkatchicago.com/",
     "facebook": "https://www.facebook.com/KitKatLoungeAndSupperClub/",
+    "id": 1600,
+    "imageURL": "https://scontent-dfw5-1.cdninstagram.com/vp/2df92b22dd775080faa34d2c75e1aaf5/5D3D3F94/t51.2885-19/s320x320/19931636_1882657655285116_5784495519422218240_a.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/kitkatlounge/?hl=en",
+    "name": "Kit Kat Lounge & Supper Club",
+    "phone": "(773) 525-1111",
+    "shows": [{
+      "category": "drag show",
+      "dayOfWeek": ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+      "frequency": "nightly",
+      "id": 1601,
+      "notes": "Kit Kat's nightly shows run every 20 minutes starting at 6.30pm through midnight.",
+      "reoccuring": true,
+      "startTime": 1830,
+      "title": "Kit Kat's Nightly Show"
+    }],
     "twitter": "https://twitter.com/kitkatlounge?lang=en",
-    "shows": [
-      {
-        "title": "Kit Kat's Nightly Show",
-        "category": "drag show",
-        "dayOfWeek": [
-          "Sunday",
-          "Monday",
-          "Tuesday",
-          "Wednesday",
-          "Thursday",
-          "Friday",
-          "Saturday"
-        ],
-        "reoccuring": true,
-        "frequency": "nightly",
-        "startTime": 1830,
-        "notes": "Kit Kat's nightly shows run every 20 minutes starting at 6.30pm through midnight."
-      }
-    ]
-  },
-  {
-    "name": "Charlie's Chicago",
+    "website": "http://www.kitkatchicago.com/"
+  }, {
     "address": "3726 N Broadway, Chicago, IL 60613",
-    "phone": "(773) 871-8887",
-    "notes": "Western-themed Boystown bar & dance club with drag shows, karaoke, bingo & late-night hours.",
-    "website": "http://www.charlieschicago.com/",
     "facebook": "https://www.facebook.com/charlieschicago/",
+    "id": 1700,
+    "imageURL": "https://scontent-dfw5-1.cdninstagram.com/vp/68fde93ed610e4343e260d0bef357bb4/5D455BF5/t51.2885-19/s320x320/21689175_312738702526354_3056968978954977280_n.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/charlieschicagobar/",
+    "name": "Charlie's Chicago",
+    "notes": "Western-themed Boystown bar & dance club with drag shows, karaoke, bingo & late-night hours.",
+    "phone": "(773) 871-8887",
+    "shows": [{
+      "category": "karaoke",
+      "dayOfWeek": "Sunday",
+      "frequency": "weekly",
+      "host": "Danika Bone't",
+      "id": 1701,
+      "reoccuring": true,
+      "startTime": 1900,
+      "title": "Sing-Sational Sunday!"
+    }, {
+      "category": "bingo",
+      "dayOfWeek": "Monday",
+      "frequency": "weekly",
+      "host": ["Darla Dae", "Danika Bone't"],
+      "id": 1702,
+      "reoccuring": true,
+      "startTime": 2100,
+      "title": "Double 'D' Bingo"
+    }, {
+      "category": "drag show",
+      "dayOfWeek": "Tuesday",
+      "frequency": "weekly",
+      "host": "Danika Bone't",
+      "id": 1703,
+      "notes": "Special guests weekly",
+      "reoccuring": true,
+      "startTime": 2330,
+      "title": "Twisted Tuesdays"
+    }, {
+      "category": "drag show",
+      "dayOfWeek": "Thursday",
+      "frequency": "weekly",
+      "host": "Alexandrea Diamond",
+      "id": 1704,
+      "notes": "1st Week Of The Month: 80’s. 2nd Week Of The Month: 90’s. 3rd Week Of The Month: Early 2000’s. 4th Week Of the Month: Body Beautiful.",
+      "reoccuring": true,
+      "startTime": 2200,
+      "title": "Throwback Thursdays"
+    }, {
+      "category": "drag show",
+      "dayOfWeek": "Friday",
+      "frequency": "weekly",
+      "host": "Veronica Pop",
+      "id": 1705,
+      "reoccuring": true,
+      "startTime": 2300,
+      "title": "Veronica's POP OFF!"
+    }, {
+      "category": "competition",
+      "dayOfWeek": "Satruday",
+      "frequency": "weekly",
+      "host": ["Veronica Pop", "Tiffany Diamond"],
+      "id": 1706,
+      "reoccuring": true,
+      "startTime": 2230,
+      "title": "#POPular"
+    }],
     "twitter": "https://twitter.com/CharliesBarChi",
-    "shows": [
-      {
-        "title": "Sing-Sational Sunday!",
-        "category": "karaoke",
-        "dayOfWeek": "Sunday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 1900,
-        "host": "Danika Bone't"
-      },
-      {
-        "title": "Double 'D' Bingo",
-        "category": "bingo",
-        "dayOfWeek": "Monday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2100,
-        "host": [
-          "Darla Dae", 
-          "Danika Bone't"
-        ]
-      },
-      {
-        "title": "Twisted Tuesdays",
-        "category": "drag show",
-        "dayOfWeek": "Tuesday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2330,
-        "host": "Danika Bone't",
-        "notes": "Special guests weekly"
-      },
-      {
-        "title": "Throwback Thursdays",
-        "category": "drag show",
-        "dayOfWeek": "Thursday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2200,
-        "host": "Alexandrea Diamond",
-        "notes": "1st Week Of The Month: 80’s. 2nd Week Of The Month: 90’s. 3rd Week Of The Month: Early 2000’s. 4th Week Of the Month: Body Beautiful."
-      },
-      {
-        "title": "Veronica's POP OFF!",
-        "category": "drag show",
-        "dayOfWeek": "Friday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2300,
-        "host": "Veronica Pop"
-      },
-      {
-        "title": "#POPular",
-        "category": "competition",
-        "dayOfWeek": "Satruday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2230,
-        "host": [
-          "Veronica Pop",
-          "Tiffany Diamond"
-        ]
-      }
-    ]
-  },
-  {
-    "name": "Replay Lakeview",
+    "website": "http://www.charlieschicago.com/"
+  }, {
     "address": "3439 N Halsted St, Chicago, IL 60657",
-    "phone": "(773) 661-9632",
-    "notes": "Vintage video games entertain patrons of this funky arcade bar with beer, bourbon & cocktails.",
-    "website": "http://www.replaylakeview.com/",
     "facebook": "https://www.facebook.com/ReplayLakeview/",
+    "id": 1800,
+    "imageURL": "https://scontent-dfw5-1.cdninstagram.com/vp/4b06f9aecbebfb2d106caf7ea3ebaf01/5D2CD113/t51.2885-19/s320x320/54510895_253183035637344_6054674921122955264_n.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/replaylakeview/",
+    "name": "Replay Lakeview",
+    "notes": "Vintage video games entertain patrons of this funky arcade bar with beer, bourbon & cocktails.",
+    "phone": "(773) 661-9632",
+    "shows": [{
+      "category": "drag show",
+      "dayOfWeek": "Thursday",
+      "frequency": "2nd Thrusday",
+      "host": "Lady Ivory",
+      "id": 1801,
+      "notes": "$5 at the door",
+      "reoccuring": true,
+      "startTime": 2200,
+      "title": "Killer Babes"
+    }],
     "twitter": "https://twitter.com/replaylakeview?lang=en",
-    "shows": [
-      {
-        "title": "Killer Babes",
-        "category": "drag show",
-        "dayOfWeek": "Thursday",
-        "reoccuring": true,
-        "frequency": "2nd Thrusday",
-        "startTime": 2200,
-        "host": "Lady Ivory",
-        "notes": "$5 at the door"
-      }
-    ]
-  },
-  {
-    "name": "Smartbar",
+    "website": "http://www.replaylakeview.com/"
+  }, {
     "address": "3730 N Clark St, Chicago, IL 60613",
-    "phone": "(773) 549-4140",
-    "notes": "This lively, hip nightspot features DJs spinning techno dance music, beer & cocktails.",
-    "website": "https://smartbarchicago.com/",
     "facebook": "https://www.facebook.com/smartbarchicago",
+    "id": 1900,
+    "imageURL": "http://gapersblock.com/transmission/bb5fa4c497ebe35d10b8ed067b82b21e.eps.jpg",
     "instagram": "https://www.instagram.com/smartbarchicago/",
+    "name": "Smartbar",
+    "notes": "This lively, hip nightspot features DJs spinning techno dance music, beer & cocktails.",
+    "phone": "(773) 549-4140",
+    "shows": [{
+      "category": "drag show",
+      "dayOfWeek": "Sunday",
+      "frequency": "weekly",
+      "host": "Lucy Stoole",
+      "id": 1901,
+      "reoccuring": true,
+      "startTime": 2200,
+      "title": "Queen!"
+    }],
     "twitter": "https://twitter.com/smartbar",
-    "shows": [
-      {
-        "title": "Queen!",
-        "category": "drag show",
-        "dayOfWeek": "Sunday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2200,
-        "host": "Lucy Stoole"
-      }
-    ]
-  },
-  {
-    "name": "Splash Chicago",
+    "website": "https://smartbarchicago.com/"
+  }, {
     "address": "3339 N Halsted St, Chicago, IL 60657",
-    "phone": "(773) 904-7338",
-    "website": "https://splash-chicago.com/",
     "facebook": "https://www.facebook.com/SplashChicagoIL/",
+    "id": 2000,
+    "imageURL": "https://scontent-dfw5-1.cdninstagram.com/vp/23524d8438572f3f4226ce19c7cc17fc/5D2DA0C5/t51.2885-19/s320x320/30077297_2117067268524812_4056447219224543232_n.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/splash_chicago/",
+    "name": "Splash Chicago",
+    "phone": "(773) 904-7338",
+    "shows": [{
+      "category": "competition",
+      "dayOfWeek": "Monday",
+      "frequency": "weekly",
+      "host": "Elektra Del Rio",
+      "id": 2001,
+      "notes": "This 10 week competition is about to take you on the ride of your life featuring: guest judges, weekly challenges, prizes, lip sync for your life battles and audience chosen eliminations.",
+      "reoccuring": true,
+      "startTime": 2200,
+      "title": "TENS"
+    }],
     "twitter": "https://twitter.com/Splash_Chicago",
-    "shows": [
-      {
-        "title": "TENS",
-        "category": "competition",
-        "dayOfWeek": "Monday",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 2200,
-        "host": "Elektra Del Rio",
-        "notes": "This 10 week competition is about to take you on the ride of your life featuring: guest judges, weekly challenges, prizes, lip sync for your life battles and audience chosen eliminations."
-      }
-    ]
-  },
-  {
-    "name": "Meeting House Tavern",
+    "website": "https://splash-chicago.com/"
+  }, {
     "address": "5025 N Clark St, Chicago, IL 60640",
-    "phone": "(773) 696-4211",
-    "website": "http://www.meetinghousetavern.com/",
     "facebook": "https://www.facebook.com/MeetingHouseChi",
+    "id": 2100,
+    "imageURL": "https://scontent-dfw5-1.cdninstagram.com/vp/dc393598c8355083e81b210447749477/5D30B2CA/t51.2885-19/s320x320/30920559_218883882204264_3986740088989024256_n.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/meetinghousetavernchi/",
+    "name": "Meeting House Tavern",
+    "phone": "(773) 696-4211",
+    "shows": [{
+      "category": "drag show",
+      "dayOfWeek": "Sudnay",
+      "frequency": "weekly",
+      "host": "Chamilla Foxx",
+      "id": 2101,
+      "reoccuring": true,
+      "startTime": 1400,
+      "title": "Sunday Social"
+    }],
     "twitter": "https://twitter.com/meetinghousechi",
-    "shows": [
-      {
-        "title": "Sunday Social",
-        "category": "drag show",
-        "dayOfWeek": "Sudnay",
-        "reoccuring": true,
-        "frequency": "weekly",
-        "startTime": 1400,
-        "host": "Chamilla Foxx"
-      }
-    ]
+    "website": "http://www.meetinghousetavern.com/"
   }
-],
+];
 
 const queens = [
   {
-    "name": "T Rex",
-    "instagram": "https://www.instagram.com/trexinchicago/?hl=en",
+    "bio":
+      "Larger than life. Dumber than hell. ⭐️RPDR viewings at @roscoestavern [YouTube] ⭐️Host of @dragmatinee ⭐️Resident at @hardcandyky @d.i.x._milwaukee",
     "facebook": "https://www.facebook.com/trannika",
-    "twitter": "https://twitter.com/trexinchicago?lang=en",
+    "id": 101,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/adfaa84899395612d004ad7c84c8aadd/5D4675A4/t51.2885-19/s320x320/49845470_632700483816654_184586295538876416_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/trexinchicago/?hl=en",
+    "name": "T Rex",
     "shows": [
       "Roscoe’s RPDR S11 Viewing Party",
       "XYZ",
       "Drag Matinee",
       "Crash Landing"
-    ]
+    ],
+    "twitter": "https://twitter.com/trexinchicago?lang=en"
   },
   {
-    "name": "Friday Lay",
-    "instagram": "https://www.instagram.com/fridalay69/",
+    "bio": "",
     "facebook": "https://www.facebook.com/fridalay",
-    "twitter": "https://twitter.com/fridalay?lang=en",
-    "shows": [
-      "Roscoe's Drag Race"
-    ]
+    "id": 102,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/cba48214c45c9431bf5e69eacd0c40b0/5D42533A/t51.2885-19/s320x320/15538217_217053125408871_6722936862756831232_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/fridalay69/",
+    "name": "Friday Lay",
+    "shows": ["Roscoe's Drag Race"],
+    "twitter": "https://twitter.com/fridalay?lang=en"
   },
   {
-    "name": "Bambi Banks Couleé",
-    "instagram": "https://www.instagram.com/bambi.banks/?hl=en",
+    "bio":
+      "💥Chicago’s Princess 💥Member of Maison Couleé 💥Woman of Color 💥DM to book me please! 💥Venmo: Bambi-banks1",
     "facebook": "https://www.facebook.com/bambi.banks.372",
-    "twitter": "https://twitter.com/itsbambibanks?lang=en",
-    "shows": [
-      "XYZ",
-      "Drag Matinee"
-    ]
+    "id": 103,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/351b6c9c8e71ed35c1c77050592349ca/5D3E781A/t51.2885-19/s320x320/54238024_2106929026094814_6151288054372892672_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/bambi.banks/?hl=en",
+    "name": "Bambi Banks Couleé",
+    "shows": ["XYZ", "Drag Matinee"],
+    "twitter": "https://twitter.com/itsbambibanks?lang=en"
   },
   {
-    "name": "Denali",
+    "bio":
+      "Chicago’s premier Alaskan dance and ice queen ⛸ 🏆Crash Landing Cycle 21 Winner 📍Chicago, IL Booking: DM/corderozuckerman@yahoo.com",
+    "id": 104,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/428bcc93e83c1bd35cad11b5a28e0df1/5D4A3D30/t51.2885-19/s320x320/44528662_366373510773797_5489220237263896576_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/denali_._/",
-    "shows": [
-      "XYZ",
-      "Drag Matinee"
-    ]
+    "name": "Denali",
+    "shows": ["XYZ", "Drag Matinee"]
   },
   {
-    "name": "Ashley Malone",
-    "instagram": "https://www.instagram.com/msmalone28/?hl=en",
+    "bio": "📍 Chicago Queen 📑 Booking: mydash01@gmail.com 🐥 @msmalone28",
     "facebook": "https://www.facebook.com/ashley.malone.14",
-    "twitter": "https://twitter.com/msmalone28?lang=en",
-    "shows": [
-      "XYZ",
-      "Drag Matinee"
-    ]
+    "id": 105,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/6d7e6e73462b5d1a78b94cabf5fd80b0/5D4A1B31/t51.2885-19/s320x320/19227323_1507346699329411_4342794076123299840_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/msmalone28/?hl=en",
+    "name": "Ashley Malone",
+    "shows": ["XYZ", "Drag Matinee"],
+    "twitter": "https://twitter.com/msmalone28?lang=en"
   },
   {
-    "name": "Kat Sass",
-    "instagram": "https://www.instagram.com/kat.sass/?hl=en",
+    "bio":
+      "👑Chicago Based Queer Nonbinary Glampire 👑Drag/Production Design/Art Direction 👑Native American/Greek Tragedy 👑Please DM to book 👑Venmo: @katsass",
     "facebook": "https://www.facebook.com/ihatekatsass",
-    "twitter": "https://twitter.com/ihatekatsass?lang=en",
-    "shows": [
-      "XYZ",
-      "SLAY: Afterbirth"
-    ]
+    "id": 106,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/3323d98df624de2eb095ffb9c89ba111/5D32DDAF/t51.2885-19/s320x320/45673485_490667418097105_7862612748352356352_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/kat.sass/?hl=en",
+    "name": "Kat Sass",
+    "shows": ["XYZ", "SLAY: Afterbirth"],
+    "twitter": "https://twitter.com/ihatekatsass?lang=en"
   },
   {
-    "name": "Keri Traid",
+    "bio": "100% That Bitch 😘",
+    "id": 107,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/9ae31ea2ac0366b5f94f81489e000d3e/5D2F3312/t51.2885-19/s320x320/54266446_595015444311442_7188520989909581824_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/iamkeritraid/?hl=en",
-    "shows": [
-      "XYZ"
-    ]
+    "name": "Keri Traid",
+    "shows": ["XYZ"]
   },
   {
-    "name": "Tenderoni",
+    "bio":
+      "👑Chicago Drag King 👑 🖍Freelance artist specializing in Airbrush/Handpainting🖍 🤓Goof Troop🤓 PIZZA TEE ⬇️⬇️⬇️ Bookings: booktenderoni@gmail.com",
+    "id": 108,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/13e995a8636ec47ffde09c03a0f9ed8b/5D2B0C3A/t51.2885-19/s320x320/46231105_215610492568777_3332799123098173440_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/tenderoni88/?hl=en",
-    "twitter": "https://twitter.com/tender_oni?lang=en",
-    "shows": [
-      "XYZ",
-      "SLAY: Afterbirth"
-    ]
+    "name": "Tenderoni",
+    "shows": ["XYZ", "SLAY: Afterbirth"],
+    "twitter": "https://twitter.com/tender_oni?lang=en"
   },
   {
-    "name": "Alex Kay",
+    "bio": "Just a chicken nugget girl in a BBQ world; Chicago",
+    "id": 109,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/ebeaf92df734c2e26d944f4d54527252/5D3AD9A4/t51.2885-19/s320x320/52937583_553976341772723_2228754556773203968_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/butchqween/?hl=en",
-    "twitter": "https://twitter.com/AlexKayJustOk",
-    "shows": [
-      "Squad Goals"
-    ]
+    "name": "Alex Kay",
+    "shows": ["Squad Goals"],
+    "twitter": "https://twitter.com/AlexKayJustOk"
   },
   {
-    "name": "Blondebenét",
-    "instagram": "https://www.instagram.com/blondebenet/?hl=en",
-    "twitter": "https://twitter.com/blonde_benet",
+    "bio": "A thirst trap in pastels. Chicago.",
     "facebook": "https://www.facebook.com/blondebenet",
-    "shows": [
-      "Squad Goals"
-    ]
+    "id": 110,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/3342e5a10216cf4733ed19ee7e9fb655/5D2CA04D/t51.2885-19/s320x320/50940469_344514352832657_5889399318237937664_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/blondebenet/?hl=en",
+    "name": "Blondebenét",
+    "shows": ["Squad Goals"],
+    "twitter": "https://twitter.com/blonde_benet"
   },
   {
-    "name": "Logan Zass",
+    "bio":
+      "The Pintsized Pimpin Party Princess ✌🏽 Chicago drag queen &amp; socialite #SquadGoalsChicago Talk to me nice 😇",
+    "id": 111,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/bb48186b223245b784e2ba84191c1b1a/5D43C507/t51.2885-19/s320x320/50748521_294083794552813_2422421259284381696_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/loganzass/?hl=en",
-    "shows": [
-      "Squad Goals"
-    ]
+    "name": "Logan Zass",
+    "shows": ["Squad Goals"]
   },
   {
-    "name": "Joonage À Trois",
+    "bio":
+      "Chicago drag queen Jager queen, gender monster, brat, chaotic pussy energy Host of @squadgoalschicago Joonageatrois@gmail.com",
+    "id": 112,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/030e10ab7df28aa6cbc25680911824e3/5D394BA1/t51.2885-19/s320x320/46997218_440818009784862_3017477184164986880_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/joonageatrois/?hl=en",
-    "shows": [
-      "Squad Goals"
-    ]
+    "name": "Joonage À Trois",
+    "shows": ["Squad Goals"]
   },
   {
-    "name": "Lady Ivory",
-    "instagram": "https://www.instagram.com/theladyivory/?hl=en",
+    "bio": "💚#CholaClown from Chicago💚 👕Click Below for Merch👕",
     "facebook": "https://www.facebook.com/TheLadyIvory/",
-    "shows": [
-      "SLAY: Afterbirth",
-      "Killer Babes"
-    ]
+    "id": 113,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/4d0b3df6131f8d888306a9df15cca084/5D4AD8C8/t51.2885-19/s320x320/51960968_314889779378337_6930784065515683840_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/theladyivory/?hl=en",
+    "name": "Lady Ivory",
+    "shows": ["SLAY: Afterbirth", "Killer Babes"]
   },
   {
-    "name": "Claire Voyant",
-    "instagram": "https://www.instagram.com/claire.voyant.queen/?hl=en",
-    "twitter": "https://twitter.com/_claire_voyant",
+    "bio":
+      "Chicago Based Ethereal Shapeshifter Roscoe’s Drag Race 2018 Fan Favorite &amp; Second Place 💀 Slay Host at Berlin 💀",
     "facebook": "https://www.facebook.com/claire.voyant.queen",
-    "shows": [
-      "SLAY: Afterbirth"
-    ]
+    "id": 114,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/b246ef70004ec4f6064ab1a87cf80ccc/5D43AC73/t51.2885-19/s320x320/52771929_384172695710068_8393887159051878400_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/claire.voyant.queen/?hl=en",
+    "name": "Claire Voyant",
+    "shows": ["SLAY: Afterbirth"],
+    "twitter": "https://twitter.com/_claire_voyant"
   },
   {
-    "name": "Masha Potato",
+    "bio": "Chicago drag artist, recovering carbaholic. 🤑Venmo @crinklecutqueen",
+    "id": 115,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/1181c4aab94a68f11bdd0b27da9721e6/5D40BC83/t51.2885-19/s320x320/39245126_321538398619721_6782979199884853248_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/crinklecutqueen/?hl=en",
-    "twitter": "https://twitter.com/crinklecutqueen",
-    "shows": [
-      "SLAY: Afterbirth"
-    ]
+    "name": "Masha Potato",
+    "shows": ["SLAY: Afterbirth"],
+    "twitter": "https://twitter.com/crinklecutqueen"
   },
   {
-    "name": "Siichele",
+    "bio":
+      "Qt angel/demon bb 👼🏽🔪 Queen 🦷 MUA 🦷 Queer 🦷 Libra 🦷 Chicago, IL🦷",
+    "id": 116,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/ac7b8fa47fcba73ef5acb00ffc95b89d/5D3F3A29/t51.2885-19/s320x320/52993442_2202217859839848_8598534538160766976_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/siichele/?hl=en",
-    "twitter": "https://twitter.com/siichele?lang=en",
-    "shows": [
-      "SLAY: Afterbirth"
-    ]
+    "name": "Siichele",
+    "shows": ["SLAY: Afterbirth"],
+    "twitter": "https://twitter.com/siichele?lang=en"
   },
   {
-    "name": "Laila McQueen",
+    "bio": "Not terrible, not Gr8 either. For bookings: lailamcqueen@gmail.com",
+    "id": 117,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/c01c1541be9d883f6a3c907fbc078780/5D3A8FC7/t51.2885-19/s320x320/12269932_1652815834986085_971630936_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/misslailamcqueen/?hl=en",
-    "twitter": "https://twitter.com/lailamcqueen?lang=en",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "name": "Laila McQueen",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/lailamcqueen?lang=en"
   },
   {
-    "name": "Sasha Belle",
-    "instagram": "https://www.instagram.com/sashabelley/?hl=en",
-    "twitter": "https://twitter.com/sashabelle3?lang=en",
+    "bio": "",
     "facebook": "https://www.facebook.com/Sasha-Belle-1457446307864946/",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 118,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/9e8e535948a6840c9778f3948b3bcd4c/5D2AB39C/t51.2885-19/s320x320/54196427_312652559394918_5887169852254191616_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/sashabelley/?hl=en",
+    "name": "Sasha Belle",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/sashabelle3?lang=en"
   },
   {
-    "name": "Chasity Marie",
-    "instagram": "https://www.instagram.com/_chasitymarie_/?hl=en",
-    "twitter": "https://twitter.com/_chasitymarie_?lang=en",
+    "bio":
+      "Everyones Dream Girl 💁🏼‍♀️ Female Impersonator/Drag Queen 💃 The Cabaret - Cincinnati, Ohio! For booking information PM me!",
     "facebook": "https://www.facebook.com/TheChasityMarie/",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 119,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/4628c8845ccc9f0de89c18ed68a51caf/5D4D516C/t51.2885-19/s320x320/50061688_602457636870001_2943407002811891712_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/_chasitymarie_/?hl=en",
+    "name": "Chasity Marie",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/_chasitymarie_?lang=en"
   },
   {
-    "name": "Lucy Stoole",
-    "instagram": "https://www.instagram.com/tyislucystoole/",
-    "twitter": "https://twitter.com/lucystoole?lang=en",
+    "bio":
+      "🎀💗💩International Black Bearded Beauty💩💗🎀 Chicago Nightlife Award Winner - 2016 Best Drag Entertainer",
     "facebook": "https://www.facebook.com/lucystooleisaslut",
-    "shows": [
-      "Drag Matinee",
-      "Queen!"
-    ]
+    "id": 120,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/3ffab66986f5b1d80cdd5fe46f3e65ef/5D361803/t51.2885-19/s320x320/14659376_610472812474502_5217065038937849856_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/tyislucystoole/",
+    "name": "Lucy Stoole",
+    "shows": ["Drag Matinee", "Queen!"],
+    "twitter": "https://twitter.com/lucystoole?lang=en"
   },
   {
-    "name": "Aunty Chan",
-    "instagram": "https://www.instagram.com/aunty_chan/?hl=en",
-    "twitter": "https://twitter.com/aunty_chan?lang=en",
+    "bio":
+      "❤️🧡💛💚💙💜💙💚💛🧡❤️ Double-D list Celebrity📍Chicago Drag Queen and Opinionated Scum ❤️🧡💛💚💙💜💙💚💛🧡❤️ IMHO EP. 4 💋⬇️",
     "facebook": "https://www.facebook.com/auntycherrychan",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 121,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/f0b2195af69b918c1baa1ed18c56d446/5D4AF54C/t51.2885-19/s320x320/51218190_377069173112153_1261515169956102144_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/aunty_chan/?hl=en",
+    "name": "Aunty Chan",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/aunty_chan?lang=en"
   },
   {
-    "name": "Savannah Westbrooke",
-    "instagram": "https://www.instagram.com/savannahwestbrooke/?hl=en",
-    "twitter": "https://twitter.com/sbvancartier?lang=en",
+    "bio":
+      "I'm simply a drag queen with a purpose and a message for the world...",
     "facebook": "https://www.facebook.com/simplybeautifull26",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 122,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/2b066187ea735bd70fb9c602599b0f02/5D2F8846/t51.2885-19/s320x320/47582438_311180572825000_2856242136188190720_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/savannahwestbrooke/?hl=en",
+    "name": "Savannah Westbrooke",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/sbvancartier?lang=en"
   },
   {
-    "name": "Aura Mayari",
-    "instagram": "https://www.instagram.com/auramayari/?hl=en",
+    "bio":
+      "ᜂᜇ ᜋᜌᜇᜒ DM for bookings or email: auramayari@gmail.com Hostess of Sirens of Splash every Thursday 📍Chicago",
     "facebook": "https://www.facebook.com/AuraMayari08",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 123,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/a1a3d5e0b5b00d090444e743a2bfffdd/5D3A8835/t51.2885-19/s320x320/52912677_2120891901535036_3596226380943065088_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/auramayari/?hl=en",
+    "name": "Aura Mayari",
+    "shows": ["Drag Matinee"]
   },
   {
-    "name": "Nico",
-    "instagram": "https://www.instagram.com/nicozworld/?hl=en",
-    "twitter": "https://twitter.com/nicozworld?lang=en",
+    "bio": "Crash landed here in Chicago. #alienstreetwalker. Venmo-@nicozworld",
     "facebook": "https://www.facebook.com/nicobombshell/",
-    "shows": [
-      "Crash Landing"
-    ]
+    "id": 124,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/450d71f867e0e8f5fb5f3a96612c51ea/5D4C892A/t51.2885-19/s320x320/52377309_405134256702481_4925590613857927168_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/nicozworld/?hl=en",
+    "name": "Nico",
+    "shows": ["Crash Landing"],
+    "twitter": "https://twitter.com/nicozworld?lang=en"
   },
   {
+    "bio":
+      "🖤 BLACKOUT PRINCESS 🌹 low light supermodel ♏️ scorpio sister 🤳🏽 snapchat: stevenreeder 🦄 twitter: opheliaroserade 💝 venmo: opheliaroserade 📨 opheliaroserade@gmail.com",
+    "facebook": "https://www.facebook.com/opheliaroserade",
+    "id": 125,
+    "imageURL":
+      "https://scontent-dfw5-1.cdninstagram.com/vp/7b5d95608ca4c254a2788be19c10181a/5D33E588/t51.2885-19/s320x320/40338006_890930624450153_5310156213105721344_n.jpg?_nc_ht=scontent-dfw5-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/nicozworld/?hl=en",
     "name": "Ophelia Belle",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/opheliaroserade?lang=en"
   },
   {
-    "name": "Monica Beverly Hillz",
-    "instagram": "https://www.instagram.com/monicabhillz/?hl=en",
-    "twitter": "https://twitter.com/MonicaBHillz",
+    "bio":
+      "S5 Alumni of RPDR✨’’Monica Beverly Hillz Is Very Good At Giving Face”👉Booking Info:4SOCIALSCOPE@gmail.com",
     "facebook": "https://www.facebook.com/MonicaBeverlyHillz/",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 126,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/c7fbadfc9854ea5890b0056bd8d1e73e/5D44C478/t51.2885-19/s320x320/47690220_358221554758905_4047581620746584064_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/monicabhillz/?hl=en",
+    "name": "Monica Beverly Hillz",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/MonicaBHillz"
   },
   {
-    "name": "Imp Queen",
-    "instagram": "https://www.instagram.com/imp_kid/?hl=en",
-    "twitter": "https://twitter.com/imp_kid?lang=en",
+    "bio":
+      "ts starlet ✨ 💸 venmo @imp_kid 🤑 bookings: impunderscorekid@gmail.com",
     "facebook": "https://www.facebook.com/darrenbarrere",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 127,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/220a6289cdae95f841b97559d2388896/5D2FD304/t51.2885-19/s320x320/51209151_539239709899381_1590668514195144704_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/imp_kid/?hl=en",
+    "name": "Imp Queen",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/imp_kid?lang=en"
   },
   {
-    "name": "Irregular Girl",
+    "bio":
+      "💩I’m the shits! 💋Trans Lady 💍Venmo/Paypal: imirregulargirl 📖DM for bookings 📍Chicago, IL",
+    "id": 128,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/091bc7c00b71b06285cc08eea363c930/5D328EF6/t51.2885-19/s320x320/51372188_2456159417787792_513719870043455488_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/imirregulargirl/?hl=en",
-    "shows": [
-      "Drag Matinee",
-      "SingAlong! /“Mary Poppins Returns/” Viewing"
-    ]
+    "name": "Irregular Girl",
+    "shows": ["Drag Matinee", "SingAlong! /“Mary Poppins Returns/” Viewing"]
   },
   {
-    "name": "Tiffany Diamond",
-    "instagram": "https://www.instagram.com/liketotallytiffany/?hl=en",
-    "twitter": "https://twitter.com/liketotallytiff?lang=en",
+    "bio":
+      "The Diamond standard of dolls 💖💎💅🏻💋 ✨Chicago✨ ✨LikeTotallyTiffany@gmail.com✨ ✨@Liketotallytiff on Twitter✨",
     "facebook": "https://www.facebook.com/liketotallytiffany",
-    "shows": [
-      "Drag Matinee",
-      "#POPular"
-    ]
+    "id": 129,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/01cd1b1166b0015aa1657c3bd52c38dc/5D2DAAA8/t51.2885-19/s320x320/50790891_254218258838818_4831604536009293824_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/liketotallytiffany/?hl=en",
+    "name": "Tiffany Diamond",
+    "shows": ["Drag Matinee", "#POPular"],
+    "twitter": "https://twitter.com/liketotallytiff?lang=en"
   },
   {
-    "name": "Raven Samore",
+    "bio": "",
     "facebook": "https://www.facebook.com/MissRavenSamore",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 130,
+    "imageURL":
+      "https://scontent-dfw5-1.xx.fbcdn.net/v/t1.0-9/54236881_10218721729820215_2482320157389619200_n.jpg?_nc_cat=105&_nc_ht=scontent-dfw5-1.xx&oh=4a491ca21b16648510a9676438ba0e82&oe=5D3A5F6E",
+    "name": "Raven Samore",
+    "shows": ["Drag Matinee"]
   },
   {
-    "name": "Jasmine Masters",
-    "instagram": "https://www.instagram.com/msjasminemasters/?hl=en",
-    "twitter": "https://twitter.com/Jasminejmasters?lang=en",
+    "bio":
+      "Rupaul show , YouTube Jasmine Masters For JUSH &amp; other $25 tees and $20tanks. Hit the PayPal link leave size &amp; color in the memo @jush_merch",
     "facebook": "https://www.facebook.com/msjasminemasters/",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 131,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/ac3c36ee1820a971093be0c6067e4540/5D4DEAFF/t51.2885-19/s320x320/53067103_473850296485005_1723285413394644992_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/msjasminemasters/?hl=en",
+    "name": "Jasmine Masters",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/Jasminejmasters?lang=en"
   },
   {
-    "name": "The Princess",
-    "instagram": "https://www.instagram.com/thedragprincess/?hl=en",
-    "twitter": "https://twitter.com/thedragprincess?lang=en",
+    "bio":
+      "Host/emcee/Playmate @playnashville Snap: @thedragprincess twitter: @thedragprincess #dragllama",
     "facebook": "https://www.facebook.com/TheDragPrincess/",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 132,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/62e4dfe7f83d963986058c9c651d31fa/5D348DE2/t51.2885-19/s320x320/30086594_468301443589171_8364667341190987776_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/thedragprincess/?hl=en",
+    "name": "The Princess",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/thedragprincess?lang=en"
   },
   {
-    "name": "Julia Starr",
-    "instagram": "https://www.instagram.com/julia_starr__/",
+    "bio":
+      "Bohemian artist I go where my Art takes me . Renaissance girl /Fashion Designer/Painter/Makeup Artist/Performer . Humbleness is key it allows u 2 grow",
     "facebook": "https://www.facebook.com/Thejuliastarr/",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 133,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/f83638e064f4f7961743157f6078cfc5/5D4B826A/t51.2885-19/s320x320/54513306_2371220143203974_1991202904928681984_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/julia_starr__/",
+    "name": "Julia Starr",
+    "shows": ["Drag Matinee"]
   },
   {
-    "name": "Tracey Ottomey",
-    "instagram": "https://www.instagram.com/traceyottomey/",
-    "twitter": "https://twitter.com/traceyottomey?lang=en",
+    "bio":
+      "I’m obviously a woman. You can see me at @tribenashville every Monday at 9:30PM and Thursday for Bingo at 7PM and Karaoke to follow RPDR Untucked.",
     "facebook": "https://www.facebook.com/tracey.ottomey",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 134,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/8c13e496bf460931565b18bee1603419/5D34EF73/t51.2885-19/s320x320/18513529_232189897266566_4086778188074582016_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/traceyottomey/",
+    "name": "Tracey Ottomey",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/traceyottomey?lang=en"
   },
   {
-    "name": "Cleo Pockalipps",
+    "bio": "Roscoe's Drag Race Winner 2018",
+    "id": 135,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/7f9d221c50c215fc5cc6195b9538f9ca/5D373A16/t51.2885-19/s320x320/50855065_1314894598666233_6892635032121245696_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/cleopockalipps/?hl=en",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "name": "Cleo Pockalipps",
+    "shows": ["Drag Matinee"]
   },
   {
-    "name": "Kahmora Hall",
+    "bio": "📍Chicago ✨Mackie Girl",
+    "id": 136,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/b3fb85b6b624f8ff67172147b0ab4b8f/5D47B307/t51.2885-19/s320x320/40048287_2112346195751835_3954482616853331968_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/kahmorahall/",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "name": "Kahmora Hall",
+    "shows": ["Drag Matinee"]
   },
   {
-    "name": "Dixie Lynn Cartwright",
-    "instagram": "https://www.instagram.com/dixielynncartwright/?hl=en",
-    "twitter": "https://twitter.com/thedixielynn?lang=en",
+    "bio": "Chicago🌃Drag queen👸🏼Camel fart🐫💨",
     "facebook": "https://www.facebook.com/DixieLynnCartwright/",
+    "id": 137,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/4ca3c9836b8218ea201a2f756eb47144/5D41A0CF/t51.2885-19/s320x320/43180155_346383522792646_6141244861761716224_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/dixielynncartwright/?hl=en",
+    "name": "Dixie Lynn Cartwright",
     "shows": [
       "Chicago's RuPaul's Drag Race Season 11 Viewing Party",
       "Shantay You Stay!",
       "Dixie Wins A Talent Show"
-    ]
+    ],
+    "twitter": "https://twitter.com/thedixielynn?lang=en"
   },
   {
-    "name": "DiDa Ritz",
-    "instagram": "https://www.instagram.com/didaswag/?hl=en",
+    "bio":
+      "#CheeseCake 💝$🎉RuPaul's Drag Race S4 royalty #Top5 Mova of 'The House Of Ritz' For Booking info please contact ZavierHairston201@gmail.com",
     "facebook": "https://www.facebook.com/DiDaHallRitz",
-    "shows": [
-      "Chicago's RuPaul's Drag Race Season 11 Viewing Party"
-    ]
+    "id": 138,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/93da815017fec99b6380299b87315ab0/5D345DCE/t51.2885-19/s320x320/13151047_250831145305986_1036211126_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/didaswag/?hl=en",
+    "name": "DiDa Ritz",
+    "shows": ["Chicago's RuPaul's Drag Race Season 11 Viewing Party"]
   },
   {
-    "name": "Danika Bone't",
-    "instagram": "https://www.instagram.com/danikabonet/",
-    "twitter": "https://twitter.com/danikastanikan",
+    "bio":
+      "The Dancing/Singing Marshmallow Hostess at Charlie's Chicago lgb(T) 💉 9/23/2018 “Are you a Danika Stanika?!”",
     "facebook": "https://www.facebook.com/DanikaBonet",
+    "id": 139,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/58c15f0b6d3f8ecef78d846671f01100/5D41915B/t51.2885-19/s320x320/46352163_1954049874680422_8569272629620375552_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/danikabonet/",
+    "name": "Danika Bone't",
     "shows": [
       "Shantay You Stay!",
       "Sing-Sational Sunday!",
       "Double 'D' Bingo",
       "Twisted Tuesdays"
-    ]
+    ],
+    "twitter": "https://twitter.com/danikastanikan"
   },
   {
-    "name": "Alexis Bevels",
-    "instagram": "https://www.instagram.com/alexisbevels/?hl=en",
-    "twitter": "https://twitter.com/AlexisBevels",
+    "bio":
+      "🎤 Chicago’s live singing, tap dancing, roller skating queen! Winner of season 1 of @campwannakiki! 🌲 ⛺️ 🌳",
     "facebook": "https://www.facebook.com/alexis.bevels",
-    "shows": [
-      "Dixie Wins A Talent Show",
-      "Charity HamBingo Mary’s"
-    ]
+    "id": 140,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/d2aad2feede1c06ade571accd845d69d/5D2FFA3B/t51.2885-19/s320x320/32443524_176604419692617_57187081524346880_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/alexisbevels/?hl=en",
+    "name": "Alexis Bevels",
+    "shows": ["Dixie Wins A Talent Show", "Charity HamBingo Mary’s"],
+    "twitter": "https://twitter.com/AlexisBevels"
   },
   {
-    "name": "Serena Cha Cha",
+    "bio":
+      "Rupaul’s Drag Race Makeup/Wigs/Costumes @makeupbymyron “ChaCha Life” 👇👇👇",
+    "id": 141,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/166695e4433509e4aa0a1a24ef77a340/5D455A0E/t51.2885-19/11373805_1621318594806044_1681582767_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/myron.morgan/?hl=en",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "name": "Serena Cha Cha",
+    "shows": ["Drag Matinee"]
   },
   {
-    "name": "Gilda Wabbit",
-    "instagram": "https://www.instagram.com/gildawabbit/?hl=en",
-    "twitter": "https://twitter.com/gildawabbit?lang=en",
+    "bio": "It’s Wabbit Season, fire! Bookings at GildaWabbit@gmail.com 💖",
     "facebook": "https://www.facebook.com/GildaWabbit/",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 142,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/734741be52a2938e5b9421396de7da76/5D2D75F1/t51.2885-19/s320x320/40026246_301654397311064_644948494078967808_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/gildawabbit/?hl=en",
+    "name": "Gilda Wabbit",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/gildawabbit?lang=en"
   },
   {
-    "name": "Umi Naughty",
-    "instagram": "https://www.instagram.com/uminaughty/",
-    "twitter": "https://twitter.com/theuminaughty",
+    "bio":
+      "🙊 Louisville’s Dirty Little Secret 🙊 📆 Bookings: theuminaughty@gmail.com 📆",
     "facebook": "https://www.facebook.com/umiinaughttyy/",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 143,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/cd442181119c1fb8cf1756ff2325b762/5D435C43/t51.2885-19/s320x320/49679202_284148878933555_1118853390223278080_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/uminaughty/",
+    "name": "Umi Naughty",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/theuminaughty"
   },
   {
-    "name": "Zsa Zsa Gabortion",
-    "instagram": "https://www.instagram.com/missgabortion/",
-    "twitter": "https://twitter.com/missgabortion",
+    "bio":
+      "Reverend Mother of the Bene Gesseritt, Bearer of the Holey Barbie-Doll Crotch, the Rebel from the Waist Down. I’ll definitely sew for you. DM me!",
     "facebook": "https://www.facebook.com/missgabortionif.unasty",
-    "shows": [
-      "Drag Matinee"
-    ]
+    "id": 144,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/5bffbc6b71f8e4bd1b5dceaa1945d84d/5D2936A0/t51.2885-19/s320x320/26869961_839543002900673_864448278119317504_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/missgabortion/",
+    "name": "Zsa Zsa Gabortion",
+    "shows": ["Drag Matinee"],
+    "twitter": "https://twitter.com/missgabortion"
   },
   {
-    "name": "Elektra Del Rio",
-    "instagram": "https://www.instagram.com/elektradelrio/?hl=en",
-    "twitter": "https://twitter.com/elektradelrio?lang=en",
+    "bio":
+      "Hi everyone 👋🏽 Chanel Beauty Business Manager Entertainer &amp; MC by night ✌🏽 SC/Twitter @elektradelrio",
     "facebook": "https://www.facebook.com/ElektraDelRio",
-    "shows": [
-      "Drag Matinee",
-      "TENS"
-    ]
+    "id": 145,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/eaf0707c9f11282a7d0956891491c02a/5D4F7635/t51.2885-19/s320x320/41955919_260955281232761_6707250534090276864_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/elektradelrio/?hl=en",
+    "name": "Elektra Del Rio",
+    "shows": ["Drag Matinee", "TENS"],
+    "twitter": "https://twitter.com/elektradelrio?lang=en"
   },
   {
-    "name": "Abhijeet",
-    "instagram": "https://www.instagram.com/bon_abhijeet/?hl=en",
-    "twitter": "https://twitter.com/bon_abhijeet",
+    "bio":
+      "👸🏽 Slumbitch Millionaire 🏠 Chicago | ❤️ Mumbai 💋 Every THURSDAY @berlinnightclub 💋 🥰 THAT girl at @aqueerpride 🥰 ⬇️ Buy my pins ⬇️",
     "facebook": "https://www.facebook.com/BonAbhijeet",
-    "shows": [
-      "SingAlong! “Mary Poppins Returns” Viewing Party!"
-    ]
+    "id": 146,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/97d86e71a1dc02c7f6df8ec84a440564/5D4BE9ED/t51.2885-19/s320x320/51739974_2575683252506804_3605265732322983936_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/bon_abhijeet/?hl=en",
+    "name": "Abhijeet",
+    "shows": ["SingAlong! “Mary Poppins Returns” Viewing Party!"],
+    "twitter": "https://twitter.com/bon_abhijeet"
   },
   {
-    "name": "Kenzie Coulee",
+    "bio":
+      "actual goddess / non-playable character / reptilian humanoid Maison Couleé 👑 👩‍👧‍👧✨ BOOK : kenziecoulee@gmail.com Venmo : @kenziecoulee",
+    "id": 147,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/ac1eec2cedf917e701916bdefa480e67/5D35788B/t51.2885-19/s320x320/50574467_247231406153269_5896326885738020864_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/kenziecoulee/n",
-    "shows": [
-      "Friday's with Kenzie Coulee"
-    ]
+    "name": "Kenzie Coulee",
+    "shows": ["Friday's with Kenzie Coulee"]
   },
   {
-    "name": "Khloe Park",
-    "instagram": "https://www.instagram.com/_khloepark/",
-    "twitter": "https://twitter.com/_khloepark",
+    "bio":
+      "📍 Chicago 🌟 Socialite 👸🏽 Homecoming Queen 2012 🎀 The girl next door... that does drag",
     "facebook": "https://www.facebook.com/khloe.park.90",
-    "shows": [
-      "Frat Night",
-      "Drag Matinee"
-    ]
+    "id": 148,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/8e3b398d97298131447643dabef7d1d0/5D431EDD/t51.2885-19/s320x320/52442028_1259707284177485_6217925455517843456_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/_khloepark/",
+    "name": "Khloe Park",
+    "shows": ["Frat Night", "Drag Matinee"],
+    "twitter": "https://twitter.com/_khloepark"
   },
   {
+    "bio":
+      "This spunky wild card will leave you in stitches, whether she’s acting as host, comedian or entertainer.",
+    "id": 149,
+    "imageURL":
+      "http://beautiesandbeaus.com/wp-content/uploads/2015/10/RuffC.jpg",
     "name": "Mz. Ruff ‘N Stuff",
     "shows": [
       "Ruffy’s Lipstick & Mascara",
@@ -1016,945 +1053,107 @@ const queens = [
     ]
   },
   {
-    "name": "Mimi Marks",
-    "instagram": "https://www.instagram.com/mimimarks11/?hl=en",
-    "twitter": "https://twitter.com/mimimarks11?lang=en",
+    "bio":
+      "Showgirl/Entertainer from Chicago💖! #girlslikeus #transisbeautiful #MIQ2005 🦄 Snapchat/twitter: @mimimarks11",
     "facebook": "https://www.facebook.com/mimi.marks.319",
-    "shows": [
-      "Honeys on Halsted"
-    ]
+    "id": 150,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/9d2953c03ca1ca6dc5f163cfa6dd564c/5D4E283E/t51.2885-19/s320x320/29095940_293625631169774_6354641656188239872_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/mimimarks11/?hl=en",
+    "name": "Mimi Marks",
+    "shows": ["Honeys on Halsted"],
+    "twitter": "https://twitter.com/mimimarks11?lang=en"
   },
   {
-    "name": "Naysha Lopez",
-    "instagram": "https://www.instagram.com/nayshalopez/?hl=en",
-    "twitter": "https://twitter.com/nayshalopez",
+    "bio":
+      "RPDR S8 💄 #TheBeauty 💅🏽 Miss Continental 13/14 👑 📧 nayshalopez@gmail.com for bookings... ❤💋",
     "facebook": "https://www.facebook.com/nayshalopez2014/",
-    "shows": [
-      "Beauties & Beaus"
-    ]
+    "id": 151,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/38eb40ebda7794c98b6b60d536faf4fc/5D3C2A78/t51.2885-19/s320x320/46411704_1201154766715423_484855774258921472_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/nayshalopez/?hl=en",
+    "name": "Naysha Lopez",
+    "shows": ["Beauties & Beaus"],
+    "twitter": "https://twitter.com/nayshalopez"
   },
   {
+    "bio": "",
+    "id": 152,
+    "imageURL": "Granny-Mattress.jpg",
     "name": "Granny Mattress",
-    "shows": [
-      "Charity HamBingo Mary’s"
-    ]
+    "shows": ["Charity HamBingo Mary’s"]
   },
   {
-    "name": "Fay Ludes",
-    "instagram": "https://www.instagram.com/fayludes/",
-    "twitter": "https://twitter.com/melisser?lang=en",
+    "bio":
+      "💊Chicago’s Drag Disco Biscuit💊 ✨Host @maryschicago✨ Tues: Let’s Make a Diva 1st Sun: Divas Brunch 2nd Fri: Let’s Make a Diva 4th Fri: HypeHerHour 🧡🌱",
     "facebook": "https://www.facebook.com/fay.ludes.1",
-    "shows": [
-      "Let’s Make a DIVA!"
-    ]
+    "id": 153,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/ea4ca467d510636390343c37dcf7820d/5D3B7C8F/t51.2885-19/s320x320/43143904_553440405077552_6966782853598150656_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/fayludes/",
+    "name": "Fay Ludes",
+    "shows": ["Let’s Make a DIVA!"],
+    "twitter": "https://twitter.com/melisser?lang=en"
   },
   {
-    "name": "Diana Tunnel",
-    "instagram": "https://www.instagram.com/dianatunnel13/",
-    "twitter": "https://twitter.com/DiannaTunnel",
+    "bio":
+      "Chicago's backwoods Barbie For bookings, email dianatunnel13@gmail.com",
     "facebook": "https://www.facebook.com/diana.tunnel.5",
-    "shows": [
-      "Drag Race at Mary's"
-    ]
+    "id": 154,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/0ecb820068c81915ee419a18fe80578e/5D3CFAE3/t51.2885-19/s320x320/47693299_276593406371651_5843873313440399360_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/dianatunnel13/",
+    "name": "Diana Tunnel",
+    "shows": ["Drag Race at Mary's"],
+    "twitter": "https://twitter.com/DiannaTunnel"
   },
   {
-    "name": "Darla Dae",
-    "instagram": "https://www.instagram.com/chgodarla/",
+    "bio": "The Bingo Hostess at Charlie's Chicago",
     "facebook": "https://www.facebook.com/darla.dae",
-    "shows": [
-      "Double 'D' Bingo"
-    ]
+    "id": 155,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/640557d74515923d83777a4f114803e1/5D37D05B/t51.2885-19/s150x150/13740926_1730091973931368_1603088894_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/chgodarla/",
+    "name": "Darla Dae",
+    "shows": ["Double 'D' Bingo"]
   },
   {
-    "name": "Alexandrea Diamond",
+    "bio":
+      "| Show Director • Charlies Chicago • | Miss Chicago Continental 2018-2019 | | Miss Latina Continental 2018-2019 | | Miss Primavera | Miss GLK |",
+    "id": 156,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/c2ff99efc34d0a4500892a3dd58e354c/5D382B26/t51.2885-19/s320x320/40661544_264945167683438_938728822675603456_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
     "instagram": "https://www.instagram.com/alexandrea.diamond/?hl=en",
-    "shows": [
-      "Throwback Thursdays"
-    ]
+    "name": "Alexandrea Diamond",
+    "shows": ["Throwback Thursdays"]
   },
   {
-    "name": "Veronica Pop",
-    "instagram": "https://www.instagram.com/vickyypop/?hl=en",
-    "twitter": "https://twitter.com/martinthelamest?lang=en",
+    "bio":
+      "✨Same Girl, Same✨ Host of #POPOFF &amp; #POPular at Charlie's Chicago EVERY FRIDAY &amp; SATURDAY NIGHT! 📸 youtube.com/vickyypop",
     "facebook": "https://www.facebook.com/VeronicaPopOfficial/",
-    "shows": [
-      "Throwback Thursdays",
-      "#POPular"
-    ]
+    "id": 157,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/99d5995e5b8c89c20c368d26ce948cfe/5D34BA04/t51.2885-19/s320x320/52173643_388723338611022_7452198378059857920_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/vickyypop/?hl=en",
+    "name": "Veronica Pop",
+    "shows": ["Throwback Thursdays", "#POPular"],
+    "twitter": "https://twitter.com/martinthelamest?lang=en"
   },
   {
-    "name": "Chamilla Foxx",
-    "instagram": "https://www.instagram.com/chamilla_foxx/",
-    "twitter": "https://twitter.com/chamillafoxx?lang=en",
+    "bio":
+      "HBIC at @styledbychamilla 💇🏽‍♀️ Host of @sundaysocialchi💃🏽 2 X's in my name cause I'm extra af 😜",
     "facebook": "https://www.facebook.com/chamilla.foxx",
-    "shows": [
-      "Sunday Social"
-    ]
+    "id": 158,
+    "imageURL":
+      "https://scontent-ort2-1.cdninstagram.com/vp/9ea2e8ba35934147277db7f6b34cd28a/5D503995/t51.2885-19/s320x320/53843332_2074262452864071_1373758445110427648_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    "instagram": "https://www.instagram.com/chamilla_foxx/",
+    "name": "Chamilla Foxx",
+    "shows": ["Sunday Social"],
+    "twitter": "https://twitter.com/chamillafoxx?lang=en"
   }
-],
-
-const queensInsta = [
-  {
-    query: "https://www.instagram.com/trexinchicago",
-    profileUrl: "https://www.instagram.com/trexinchicago/",
-    bio: "Larger than life. Dumber than hell. ⭐️RPDR viewings at @roscoestavern [YouTube] ⭐️Host of @dragmatinee ⭐️Resident at @hardcandyky @d.i.x._milwaukee",
-    followersCount: 65025,
-    followingCount: 1852,
-    status: "Following",
-    fullName: "T REX",
-    instagramID: "180355",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 61,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/adfaa84899395612d004ad7c84c8aadd/5D4675A4/t51.2885-19/s320x320/49845470_632700483816654_184586295538876416_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1823,
-    profileName: "trexinchicago",
-    website: "https://elitequeens.com/collections/trannika-rex",
-    timestamp: "2019-04-01T04:48:12.996Z"
-  },
-  {
-    query: "https://www.instagram.com/fridalay69",
-    profileUrl: "https://www.instagram.com/fridalay69/",
-    bio: "",
-    followersCount: 1037,
-    followingCount: 234,
-    fullName: "Frida Lay",
-    instagramID: "3978860642",
-    mutualFollowersCount: 2,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/cba48214c45c9431bf5e69eacd0c40b0/5D42533A/t51.2885-19/s320x320/15538217_217053125408871_6722936862756831232_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 22,
-    profileName: "fridalay69",
-    timestamp: "2019-04-01T04:48:18.819Z"
-  },
-  {
-    query: "https://www.instagram.com/bambi.banks",
-    profileUrl: "https://www.instagram.com/bambi.banks/",
-    bio: "💥Chicago’s Princess 💥Member of Maison Couleé 💥Woman of Color 💥DM to book me please! 💥Venmo: Bambi-banks1",
-    followersCount: 9675,
-    followingCount: 1240,
-    status: "Following",
-    fullName: "Bambi Banks-Couleé",
-    instagramID: "4163973564",
-    mutualFollowersCount: 32,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/351b6c9c8e71ed35c1c77050592349ca/5D3E781A/t51.2885-19/s320x320/54238024_2106929026094814_6151288054372892672_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 207,
-    profileName: "bambi.banks",
-    website: "https://www.youtube.com/channel/UCTV7-UmOK8INXL-o9S5ypuw",
-    timestamp: "2019-04-01T04:48:23.616Z"
-  },
-  {
-    query: "https://www.instagram.com/denali_._",
-    profileUrl: "https://www.instagram.com/denali_._/",
-    bio: "Chicago’s premier Alaskan dance and ice queen ⛸ 🏆Crash Landing Cycle 21 Winner 📍Chicago, IL Booking: DM/corderozuckerman@yahoo.com",
-    followersCount: 1681,
-    followingCount: 780,
-    fullName: "Denali",
-    instagramID: "7432685186",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 14,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/428bcc93e83c1bd35cad11b5a28e0df1/5D4A3D30/t51.2885-19/s320x320/44528662_366373510773797_5489220237263896576_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 81,
-    profileName: "denali_._",
-    timestamp: "2019-04-01T04:48:29.211Z"
-  },
-  {
-    query: "https://www.instagram.com/msmalone28",
-    profileUrl: "https://www.instagram.com/msmalone28/",
-    bio: "📍 Chicago Queen 📑 Booking: mydash01@gmail.com 🐥 @msmalone28",
-    followersCount: 944,
-    followingCount: 625,
-    fullName: "💋Ashley Malone",
-    instagramID: "923959531",
-    mutualFollowersCount: 7,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/6d7e6e73462b5d1a78b94cabf5fd80b0/5D4A1B31/t51.2885-19/s320x320/19227323_1507346699329411_4342794076123299840_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 166,
-    profileName: "msmalone28",
-    website: "http://www.facebook.com/ashley.malone.14",
-    timestamp: "2019-04-01T04:48:34.919Z"
-  },
-  {
-    query: "https://www.instagram.com/kat.sass",
-    profileUrl: "https://www.instagram.com/kat.sass/",
-    bio: "👑Chicago Based Queer Nonbinary Glampire 👑Drag/Production Design/Art Direction 👑Native American/Greek Tragedy 👑Please DM to book 👑Venmo: @katsass",
-    followersCount: 11027,
-    followingCount: 2015,
-    fullName: "𝕂𝕒𝕥 𝕊𝕒𝕤𝕤",
-    instagramID: "224481659",
-    mutualFollowersCount: 26,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/3323d98df624de2eb095ffb9c89ba111/5D32DDAF/t51.2885-19/s320x320/45673485_490667418097105_7862612748352356352_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 945,
-    profileName: "kat.sass",
-    website: "https://worldofwonder.net/transformationtuesday-qwerrrkout-feat-kat-sass/",
-    timestamp: "2019-04-01T04:48:40.451Z"
-  },
-  {
-    query: "https://www.instagram.com/iamkeritraid",
-    profileUrl: "https://www.instagram.com/iamkeritraid/",
-    bio: "100% That Bitch 😘",
-    followersCount: 1042,
-    followingCount: 1384,
-    fullName: "Keri Traid",
-    instagramID: "1566264960",
-    private: "Private",
-    mutualFollowersCount: 9,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/9ae31ea2ac0366b5f94f81489e000d3e/5D2F3312/t51.2885-19/s320x320/54266446_595015444311442_7188520989909581824_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1007,
-    profileName: "iamkeritraid",
-    timestamp: "2019-04-01T04:48:43.715Z"
-  },
-  {
-    query: "https://www.instagram.com/tenderoni88",
-    profileUrl: "https://www.instagram.com/tenderoni88/",
-    bio: "👑Chicago Drag King 👑 🖍Freelance artist specializing in Airbrush/Handpainting🖍 🤓Goof Troop🤓 PIZZA TEE ⬇️⬇️⬇️ Bookings: booktenderoni@gmail.com",
-    followersCount: 10328,
-    followingCount: 1803,
-    fullName: "tenderoni88",
-    instagramID: "6373173",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 34,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/13e995a8636ec47ffde09c03a0f9ed8b/5D2B0C3A/t51.2885-19/s320x320/46231105_215610492568777_3332799123098173440_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1937,
-    profileName: "tenderoni88",
-    website: "https://tenderoni.bigcartel.com/product/tenderoni-pizza-tee",
-    timestamp: "2019-04-01T04:48:48.352Z"
-  },
-  {
-    query: "https://www.instagram.com/butchqween",
-    profileUrl: "https://www.instagram.com/butchqween/",
-    bio: "Just a chicken nugget girl in a BBQ world; Chicago",
-    followersCount: 3859,
-    followingCount: 1475,
-    fullName: "💗Alex Kay💗",
-    instagramID: "33781525",
-    mutualFollowersCount: 13,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/ebeaf92df734c2e26d944f4d54527252/5D3AD9A4/t51.2885-19/s320x320/52937583_553976341772723_2228754556773203968_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 366,
-    profileName: "butchqween",
-    website: "http://twitter.com/AlexKayJustOk",
-    timestamp: "2019-04-01T04:48:53.911Z"
-  },
-  {
-    query: "https://www.instagram.com/blondebenet",
-    profileUrl: "https://www.instagram.com/blondebenet/",
-    bio: "A thirst trap in pastels. Chicago.",
-    followersCount: 6544,
-    followingCount: 620,
-    fullName: "Blondebenét 💕💊",
-    instagramID: "31627718",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 9,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/3342e5a10216cf4733ed19ee7e9fb655/5D2CA04D/t51.2885-19/s320x320/50940469_344514352832657_5889399318237937664_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 653,
-    profileName: "blondebenet",
-    website: "http://twitter.com/blonde_benet",
-    timestamp: "2019-04-01T04:48:59.418Z"
-  },
-  {
-    query: "https://www.instagram.com/loganzass",
-    profileUrl: "https://www.instagram.com/loganzass/",
-    bio: "The Pintsized Pimpin Party Princess ✌🏽 Chicago drag queen &amp; socialite #SquadGoalsChicago Talk to me nice 😇",
-    followersCount: 2374,
-    followingCount: 1099,
-    fullName: "Logan Zass",
-    instagramID: "270615335",
-    mutualFollowersCount: 9,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/bb48186b223245b784e2ba84191c1b1a/5D43C507/t51.2885-19/s320x320/50748521_294083794552813_2422421259284381696_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 688,
-    profileName: "loganzass",
-    timestamp: "2019-04-01T04:49:04.568Z"
-  },
-  {
-    query: "https://www.instagram.com/joonageatrois",
-    profileUrl: "https://www.instagram.com/joonageatrois/",
-    bio: "Chicago drag queen Jager queen, gender monster, brat, chaotic pussy energy Host of @squadgoalschicago Joonageatrois@gmail.com",
-    followersCount: 1549,
-    followingCount: 559,
-    fullName: "Joonage À Trois",
-    instagramID: "300520601",
-    mutualFollowersCount: 8,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/030e10ab7df28aa6cbc25680911824e3/5D394BA1/t51.2885-19/s320x320/46997218_440818009784862_3017477184164986880_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 174,
-    profileName: "joonageatrois",
-    timestamp: "2019-04-01T04:49:09.388Z"
-  },
-  {
-    query: "https://www.instagram.com/theladyivory",
-    profileUrl: "https://www.instagram.com/theladyivory/",
-    bio: "💚#CholaClown from Chicago💚 👕Click Below for Merch👕",
-    followersCount: 4420,
-    followingCount: 1158,
-    fullName: "#THEIVORYLEAGUE",
-    instagramID: "31415494",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 20,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/4d0b3df6131f8d888306a9df15cca084/5D4AD8C8/t51.2885-19/s320x320/51960968_314889779378337_6930784065515683840_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1196,
-    profileName: "theladyivory",
-    website: "https://www.dragqueenmerch.com/search?q=ivory",
-    timestamp: "2019-04-01T04:49:14.577Z"
-  },
-  {
-    query: "https://www.instagram.com/claire.voyant.queen",
-    profileUrl: "https://www.instagram.com/claire.voyant.queen/",
-    bio: "Chicago Based Ethereal Shapeshifter Roscoe’s Drag Race 2018 Fan Favorite &amp; Second Place 💀 Slay Host at Berlin 💀",
-    followersCount: 4507,
-    followingCount: 1472,
-    fullName: "Claire Voyant (Nick Spindler)",
-    instagramID: "2274584267",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 14,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/b246ef70004ec4f6064ab1a87cf80ccc/5D43AC73/t51.2885-19/s320x320/52771929_384172695710068_8393887159051878400_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 458,
-    profileName: "claire.voyant.queen",
-    timestamp: "2019-04-01T04:49:18.555Z"
-  },
-  {
-    query: "https://www.instagram.com/crinklecutqueen",
-    profileUrl: "https://www.instagram.com/crinklecutqueen/",
-    bio: "Chicago drag artist, recovering carbaholic. 🤑Venmo @crinklecutqueen",
-    followersCount: 809,
-    followingCount: 596,
-    fullName: "Másha Potato",
-    instagramID: "173564140",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 6,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/1181c4aab94a68f11bdd0b27da9721e6/5D40BC83/t51.2885-19/s320x320/39245126_321538398619721_6782979199884853248_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 37,
-    profileName: "crinklecutqueen",
-    website: "http://twitter.com/crinklecutqueen",
-    timestamp: "2019-04-01T04:49:24.328Z"
-  },
-  {
-    query: "https://www.instagram.com/siichele",
-    profileUrl: "https://www.instagram.com/siichele/",
-    bio: "Qt angel/demon bb 👼🏽🔪 Queen 🦷 MUA 🦷 Queer 🦷 Libra 🦷 Chicago, IL🦷",
-    followersCount: 6067,
-    followingCount: 1488,
-    fullName: "Siichele/Michele",
-    instagramID: "7035445",
-    mutualFollowersCount: 24,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/ac7b8fa47fcba73ef5acb00ffc95b89d/5D3F3A29/t51.2885-19/s320x320/52993442_2202217859839848_8598534538160766976_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 400,
-    profileName: "siichele",
-    timestamp: "2019-04-01T04:49:28.516Z"
-  },
-  {
-    query: "https://www.instagram.com/misslailamcqueen",
-    profileUrl: "https://www.instagram.com/misslailamcqueen/",
-    bio: "Not terrible, not Gr8 either. For bookings: lailamcqueen@gmail.com",
-    followersCount: 250636,
-    followingCount: 1504,
-    fullName: "Laila McQueen",
-    instagramID: "49479585",
-    verified: "Verified",
-    mutualFollowersCount: 52,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/c01c1541be9d883f6a3c907fbc078780/5D3A8FC7/t51.2885-19/s320x320/12269932_1652815834986085_971630936_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1171,
-    profileName: "misslailamcqueen",
-    timestamp: "2019-04-01T04:49:33.836Z"
-  },
-  {
-    query: "https://www.instagram.com/sashabelley",
-    profileUrl: "https://www.instagram.com/sashabelley/",
-    bio: "",
-    followersCount: 85998,
-    followingCount: 2091,
-    fullName: "Sasha Belle",
-    instagramID: "596294452",
-    verified: "Verified",
-    mutualFollowersCount: 26,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/9e8e535948a6840c9778f3948b3bcd4c/5D2AB39C/t51.2885-19/s320x320/54196427_312652559394918_5887169852254191616_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 3354,
-    profileName: "sashabelley",
-    website: "https://www.youtube.com/channel/UC31O3PIdIoSd22oxLCWJdiQ",
-    timestamp: "2019-04-01T04:49:37.925Z"
-  },
-  {
-    query: "https://www.instagram.com/_chasitymarie_",
-    profileUrl: "https://www.instagram.com/_chasitymarie_/",
-    bio: "Everyones Dream Girl 💁🏼‍♀️ Female Impersonator/Drag Queen 💃 The Cabaret - Cincinnati, Ohio! For booking information PM me!",
-    followersCount: 10446,
-    followingCount: 1436,
-    fullName: "Chasity Marie",
-    instagramID: "1289935725",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 2,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/4628c8845ccc9f0de89c18ed68a51caf/5D4D516C/t51.2885-19/s320x320/50061688_602457636870001_2943407002811891712_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1402,
-    profileName: "_chasitymarie_",
-    timestamp: "2019-04-01T04:49:43.658Z"
-  },
-  {
-    query: "https://www.instagram.com/tyislucystoole",
-    profileUrl: "https://www.instagram.com/tyislucystoole/",
-    bio: "🎀💗💩International Black Bearded Beauty💩💗🎀 Chicago Nightlife Award Winner - 2016 Best Drag Entertainer",
-    followersCount: 34163,
-    followingCount: 1947,
-    fullName: "🎀🐷💩Lucy Stoole💩🐷🎀",
-    instagramID: "382061508",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 56,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/3ffab66986f5b1d80cdd5fe46f3e65ef/5D361803/t51.2885-19/s320x320/14659376_610472812474502_5217065038937849856_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1345,
-    profileName: "tyislucystoole",
-    website: "https://www.lucystoole.com/shop",
-    timestamp: "2019-04-01T04:49:47.835Z"
-  },
-  {
-    query: "https://www.instagram.com/aunty_chan",
-    profileUrl: "https://www.instagram.com/aunty_chan/",
-    bio: "❤️🧡💛💚💙💜💙💚💛🧡❤️ Double-D list Celebrity📍Chicago Drag Queen and Opinionated Scum ❤️🧡💛💚💙💜💙💚💛🧡❤️ IMHO EP. 4 💋⬇️",
-    followersCount: 16766,
-    followingCount: 1230,
-    status: "Following",
-    followsViewer: "Follows you",
-    fullName: "*•.¸♡ ᗩᑌᑎTY ᑕᕼᗩᑎ ♡¸.•*",
-    instagramID: "3572145048",
-    businessAccount: "Business Account",
-    businessCategory: "Grocery &amp; Convenience Stores",
-    mutualFollowersCount: 68,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/f0b2195af69b918c1baa1ed18c56d446/5D4AF54C/t51.2885-19/s320x320/51218190_377069173112153_1261515169956102144_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 193,
-    profileName: "aunty_chan",
-    website: "https://youtu.be/5zaoQCf39Sg",
-    timestamp: "2019-04-01T04:50:10.771Z"
-  },
-  {
-    query: "https://www.instagram.com/savannahwestbrooke",
-    profileUrl: "https://www.instagram.com/savannahwestbrooke/",
-    bio: "I'm simply a drag queen with a purpose and a message for the world...",
-    followersCount: 6309,
-    followingCount: 2257,
-    fullName: "Savannah Westbrooke",
-    instagramID: "4017004326",
-    businessAccount: "Business Account",
-    businessCategory: "General Interest",
-    mutualFollowersCount: 5,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/2b066187ea735bd70fb9c602599b0f02/5D2F8846/t51.2885-19/s320x320/47582438_311180572825000_2856242136188190720_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 690,
-    profileName: "savannahwestbrooke",
-    timestamp: "2019-04-01T04:50:15.570Z"
-  },
-  {
-    query: "https://www.instagram.com/auramayari",
-    profileUrl: "https://www.instagram.com/auramayari/",
-    bio: "ᜂᜇ ᜋᜌᜇᜒ DM for bookings or email: auramayari@gmail.com Hostess of Sirens of Splash every Thursday 📍Chicago",
-    followersCount: 2372,
-    followingCount: 585,
-    fullName: "Aura Mayari 🌙 Drag Queen",
-    instagramID: "5917185801",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 6,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/a1a3d5e0b5b00d090444e743a2bfffdd/5D3A8835/t51.2885-19/s320x320/52912677_2120891901535036_3596226380943065088_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 57,
-    profileName: "auramayari",
-    timestamp: "2019-04-01T04:50:20.526Z"
-  },
-  {
-    query: "https://www.instagram.com/nicozworld",
-    profileUrl: "https://www.instagram.com/nicozworld/",
-    bio: "Crash landed here in Chicago. #alienstreetwalker. Venmo-@nicozworld",
-    followersCount: 32680,
-    followingCount: 3239,
-    fullName: "Nico 👽",
-    instagramID: "175644024",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 36,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/450d71f867e0e8f5fb5f3a96612c51ea/5D4C892A/t51.2885-19/s320x320/52377309_405134256702481_4925590613857927168_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1785,
-    profileName: "nicozworld",
-    timestamp: "2019-04-01T04:50:25.748Z"
-  },
-  {
-    query: "https://www.instagram.com/monicabhillz",
-    profileUrl: "https://www.instagram.com/monicabhillz/",
-    bio: "S5 Alumni of RPDR✨’’Monica Beverly Hillz Is Very Good At Giving Face”👉Booking Info:4SOCIALSCOPE@gmail.com",
-    followersCount: 47211,
-    followingCount: 7499,
-    fullName: "Monica Beverly Hillz",
-    instagramID: "260165336",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    verified: "Verified",
-    mutualFollowersCount: 18,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/c7fbadfc9854ea5890b0056bd8d1e73e/5D44C478/t51.2885-19/s320x320/47690220_358221554758905_4047581620746584064_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 420,
-    profileName: "monicabhillz",
-    timestamp: "2019-04-01T04:50:29.759Z"
-  },
-  {
-    query: "https://www.instagram.com/imp_kid",
-    profileUrl: "https://www.instagram.com/imp_kid/",
-    bio: "ts starlet ✨ 💸 venmo @imp_kid 🤑 bookings: impunderscorekid@gmail.com",
-    followersCount: 132019,
-    followingCount: 1366,
-    fullName: "imp",
-    instagramID: "10125966",
-    verified: "Verified",
-    mutualFollowersCount: 60,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/220a6289cdae95f841b97559d2388896/5D2FD304/t51.2885-19/s320x320/51209151_539239709899381_1590668514195144704_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1093,
-    profileName: "imp_kid",
-    website: "https://www.them.us/story/imp-queen-trans-drag-queens",
-    timestamp: "2019-04-01T04:50:34.186Z"
-  },
-  {
-    query: "https://www.instagram.com/imirregulargirl",
-    profileUrl: "https://www.instagram.com/imirregulargirl/",
-    bio: "💩I’m the shits! 💋Trans Lady 💍Venmo/Paypal: imirregulargirl 📖DM for bookings 📍Chicago, IL",
-    followersCount: 1907,
-    followingCount: 552,
-    fullName: "Irregular Girl",
-    instagramID: "4104525898",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 16,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/091bc7c00b71b06285cc08eea363c930/5D328EF6/t51.2885-19/s320x320/51372188_2456159417787792_513719870043455488_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 165,
-    profileName: "imirregulargirl",
-    timestamp: "2019-04-01T04:50:38.723Z"
-  },
-  {
-    query: "https://www.instagram.com/liketotallytiffany",
-    profileUrl: "https://www.instagram.com/liketotallytiffany/",
-    bio: "The Diamond standard of dolls 💖💎💅🏻💋 ✨Chicago✨ ✨LikeTotallyTiffany@gmail.com✨ ✨@Liketotallytiff on Twitter✨",
-    followersCount: 18404,
-    followingCount: 741,
-    fullName: "Tiffany Diamond",
-    instagramID: "3988992523",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 13,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/01cd1b1166b0015aa1657c3bd52c38dc/5D2DAAA8/t51.2885-19/s320x320/50790891_254218258838818_4831604536009293824_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 142,
-    profileName: "liketotallytiffany",
-    website: "https://www.dragqueenmerch.com/collections/tiffany-diamond",
-    timestamp: "2019-04-01T04:50:43.546Z"
-  },
-  {
-    query: "https://www.instagram.com/msjasminemasters",
-    profileUrl: "https://www.instagram.com/msjasminemasters/",
-    bio: "Rupaul show , YouTube Jasmine Masters For JUSH &amp; other $25 tees and $20tanks. Hit the PayPal link leave size &amp; color in the memo @jush_merch",
-    followersCount: 241206,
-    followingCount: 1813,
-    fullName: "Jasmine JUSH Masters",
-    instagramID: "215063846",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    verified: "Verified",
-    mutualFollowersCount: 49,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/ac3c36ee1820a971093be0c6067e4540/5D4DEAFF/t51.2885-19/s320x320/53067103_473850296485005_1723285413394644992_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 4200,
-    profileName: "msjasminemasters",
-    website: "https://www.paypal.me/JnBCrew",
-    timestamp: "2019-04-01T04:50:47.567Z"
-  },
-  {
-    query: "https://www.instagram.com/thedragprincess",
-    profileUrl: "https://www.instagram.com/thedragprincess/",
-    bio: "Host/emcee/Playmate @playnashville Snap: @thedragprincess Twitter: @thedragprincess #dragllama",
-    followersCount: 79452,
-    followingCount: 1509,
-    fullName: "The. Princess.",
-    instagramID: "176629983",
-    mutualFollowersCount: 39,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/62e4dfe7f83d963986058c9c651d31fa/5D348DE2/t51.2885-19/s320x320/30086594_468301443589171_8364667341190987776_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1233,
-    profileName: "thedragprincess",
-    website: "https://www.dragqueenmerch.com/collections/the-princess",
-    timestamp: "2019-04-01T04:50:51.631Z"
-  },
-  {
-    query: "https://www.instagram.com/julia_starr__",
-    profileUrl: "https://www.instagram.com/julia_starr__/",
-    bio: "Bohemian artist I go where my Art takes me . Renaissance girl /Fashion Designer/Painter/Makeup Artist/Performer . Humbleness is key it allows u 2 grow",
-    followersCount: 6463,
-    followingCount: 2419,
-    fullName: "Julia Starr 💕💖✌️😘✌️💖💕",
-    instagramID: "969141496",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 8,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/f83638e064f4f7961743157f6078cfc5/5D4B826A/t51.2885-19/s320x320/54513306_2371220143203974_1991202904928681984_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 453,
-    profileName: "julia_starr__",
-    website: "https://www.facebook.com/tonylovesX0X0",
-    timestamp: "2019-04-01T04:50:55.878Z"
-  },
-  {
-    query: "https://www.instagram.com/traceyottomey",
-    profileUrl: "https://www.instagram.com/traceyottomey/",
-    bio: "I’m obviously a woman. You can see me at @tribenashville every Monday at 9:30PM and Thursday for Bingo at 7PM and Karaoke to follow RPDR Untucked.",
-    followersCount: 1354,
-    followingCount: 1691,
-    fullName: "TraceyOttomey",
-    instagramID: "242665343",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 3,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/8c13e496bf460931565b18bee1603419/5D34EF73/t51.2885-19/s320x320/18513529_232189897266566_4086778188074582016_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 278,
-    profileName: "traceyottomey",
-    timestamp: "2019-04-01T04:51:00.894Z"
-  },
-  {
-    query: "https://www.instagram.com/cleopockalipps",
-    profileUrl: "https://www.instagram.com/cleopockalipps/",
-    bio: "Roscoe's Drag Race Winner 2018",
-    followersCount: 863,
-    followingCount: 939,
-    fullName: "Cleo Pockalipps",
-    instagramID: "6215984552",
-    mutualFollowersCount: 6,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/7f9d221c50c215fc5cc6195b9538f9ca/5D373A16/t51.2885-19/s320x320/50855065_1314894598666233_6892635032121245696_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 47,
-    profileName: "cleopockalipps",
-    timestamp: "2019-04-01T04:51:04.983Z"
-  },
-  {
-    query: "https://www.instagram.com/kahmorahall",
-    profileUrl: "https://www.instagram.com/kahmorahall/",
-    bio: "📍Chicago ✨Mackie Girl",
-    followersCount: 5462,
-    followingCount: 454,
-    fullName: "K. Hall",
-    instagramID: "1421670968",
-    mutualFollowersCount: 20,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/b3fb85b6b624f8ff67172147b0ab4b8f/5D47B307/t51.2885-19/s320x320/40048287_2112346195751835_3954482616853331968_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 82,
-    profileName: "kahmorahall",
-    timestamp: "2019-04-01T04:51:09.954Z"
-  },
-  {
-    query: "https://www.instagram.com/dixielynncartwright",
-    profileUrl: "https://www.instagram.com/dixielynncartwright/",
-    bio: "Chicago🌃Drag queen👸🏼Camel fart🐫💨",
-    followersCount: 8423,
-    followingCount: 2050,
-    status: "Following",
-    fullName: "Dixie Lynn Cartwright",
-    instagramID: "391446331",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 32,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/4ca3c9836b8218ea201a2f756eb47144/5D41A0CF/t51.2885-19/s320x320/43180155_346383522792646_6141244861761716224_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1991,
-    profileName: "dixielynncartwright",
-    website: "https://redcap.nubic.northwestern.edu/redcap/surveys/?s=YXKMW9JFXY",
-    timestamp: "2019-04-01T04:51:14.735Z"
-  },
-  {
-    query: "https://www.instagram.com/didaswag",
-    profileUrl: "https://www.instagram.com/didaswag/",
-    bio: "#CheeseCake 💝$🎉RuPaul's Drag Race S4 royalty #Top5 Mova of 'The House Of Ritz' For Booking info please contact ZavierHairston201@gmail.com",
-    followersCount: 74168,
-    followingCount: 89,
-    fullName: "DiDa Ritz",
-    instagramID: "53515394",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    verified: "Verified",
-    mutualFollowersCount: 27,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/93da815017fec99b6380299b87315ab0/5D345DCE/t51.2885-19/s320x320/13151047_250831145305986_1036211126_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 2801,
-    profileName: "didaswag",
-    timestamp: "2019-04-01T04:51:20.118Z"
-  },
-  {
-    query: "https://www.instagram.com/danikabonet",
-    profileUrl: "https://www.instagram.com/danikabonet/",
-    bio: "The Dancing/Singing Marshmallow Hostess at Charlie's Chicago lgb(T) 💉 9/23/2018 “Are you a Danika Stanika?!”",
-    followersCount: 1214,
-    followingCount: 537,
-    fullName: "Danika Bone't",
-    instagramID: "4291786827",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 9,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/58c15f0b6d3f8ecef78d846671f01100/5D41915B/t51.2885-19/s320x320/46352163_1954049874680422_8569272629620375552_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 139,
-    profileName: "danikabonet",
-    website: "https://www.facebook.com/profile.php?id=100010982440252",
-    timestamp: "2019-04-01T04:51:24.069Z"
-  },
-  {
-    query: "https://www.instagram.com/alexisbevels",
-    profileUrl: "https://www.instagram.com/alexisbevels/",
-    bio: "🎤 Chicago’s live singing, tap dancing, roller skating queen! Winner of season 1 of @campwannakiki! 🌲 ⛺️ 🌳",
-    followersCount: 3655,
-    followingCount: 4332,
-    fullName: "Alexis Bevels ⚯͛ △⃒⃘ 🛴",
-    instagramID: "1746631900",
-    businessAccount: "Business Account",
-    businessCategory: "General Interest",
-    mutualFollowersCount: 13,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/d2aad2feede1c06ade571accd845d69d/5D2FFA3B/t51.2885-19/s320x320/32443524_176604419692617_57187081524346880_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 147,
-    profileName: "alexisbevels",
-    website: "https://www.youtube.com/channel/UCTqkoKWQ0DowWAZ0Pef_5Yg",
-    timestamp: "2019-04-01T04:51:29.859Z"
-  },
-  {
-    query: "https://www.instagram.com/myron.morgan",
-    profileUrl: "https://www.instagram.com/myron.morgan/",
-    bio: "Rupaul’s Drag Race Makeup/Wigs/Costumes @makeupbymyron “ChaCha Life” 👇👇👇",
-    followersCount: 25300,
-    followingCount: 1222,
-    fullName: "Serena ChaCha",
-    instagramID: "27262393",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    verified: "Verified",
-    mutualFollowersCount: 11,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/166695e4433509e4aa0a1a24ef77a340/5D455A0E/t51.2885-19/11373805_1621318594806044_1681582767_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 893,
-    profileName: "myron.morgan",
-    website: "https://youtu.be/EEyLpXqeCcY",
-    timestamp: "2019-04-01T04:51:34.754Z"
-  },
-  {
-    query: "https://www.instagram.com/gildawabbit",
-    profileUrl: "https://www.instagram.com/gildawabbit/",
-    bio: "It’s Wabbit Season, fire! Bookings at GildaWabbit@gmail.com 💖",
-    followersCount: 9853,
-    followingCount: 1500,
-    fullName: "Gilda Wabbit",
-    instagramID: "2226723079",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 11,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/734741be52a2938e5b9421396de7da76/5D2D75F1/t51.2885-19/s320x320/40026246_301654397311064_644948494078967808_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 892,
-    profileName: "gildawabbit",
-    website: "http://www.gildawabbit.com/",
-    timestamp: "2019-04-01T04:51:39.481Z"
-  },
-  {
-    query: "https://www.instagram.com/uminaughty",
-    profileUrl: "https://www.instagram.com/uminaughty/",
-    bio: "🙊 Louisville’s Dirty Little Secret 🙊 📆 Bookings: theuminaughty@gmail.com 📆",
-    followersCount: 1491,
-    followingCount: 949,
-    fullName: "Umi Naughty",
-    instagramID: "492387294",
-    businessAccount: "Business Account",
-    businessCategory: "Local Events",
-    mutualFollowersCount: 2,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/cd442181119c1fb8cf1756ff2325b762/5D435C43/t51.2885-19/s320x320/49679202_284148878933555_1118853390223278080_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 484,
-    profileName: "uminaughty",
-    website: "https://m.facebook.com/umiinaughttyy/",
-    timestamp: "2019-04-01T04:51:43.908Z"
-  },
-  {
-    query: "https://www.instagram.com/missgabortion",
-    profileUrl: "https://www.instagram.com/missgabortion/",
-    bio: "Reverend Mother of the Bene Gesseritt, Bearer of the Holey Barbie-Doll Crotch, the Rebel from the Waist Down. I’ll definitely sew for you. DM me!",
-    followersCount: 1925,
-    followingCount: 1930,
-    fullName: "Zsa Zsa Gabortion",
-    instagramID: "965740",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 1,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/5bffbc6b71f8e4bd1b5dceaa1945d84d/5D2936A0/t51.2885-19/s320x320/26869961_839543002900673_864448278119317504_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 3166,
-    profileName: "missgabortion",
-    timestamp: "2019-04-01T04:51:48.658Z"
-  },
-  {
-    query: "https://www.instagram.com/elektradelrio",
-    profileUrl: "https://www.instagram.com/elektradelrio/",
-    bio: "Hi everyone 👋🏽 Chanel Beauty Business Manager Entertainer &amp; MC by night ✌🏽 SC/Twitter @elektradelrio",
-    followersCount: 3853,
-    followingCount: 2785,
-    fullName: "Elektra Del Rio",
-    instagramID: "41534161",
-    mutualFollowersCount: 5,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/eaf0707c9f11282a7d0956891491c02a/5D4F7635/t51.2885-19/s320x320/41955919_260955281232761_6707250534090276864_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 294,
-    profileName: "elektradelrio",
-    timestamp: "2019-04-01T04:51:53.795Z"
-  },
-  {
-    query: "https://www.instagram.com/bon_abhijeet",
-    profileUrl: "https://www.instagram.com/bon_abhijeet/",
-    bio: "👸🏽 Slumbitch Millionaire 🏠 Chicago | ❤️ Mumbai 💋 Every THURSDAY @berlinnightclub 💋 🥰 THAT girl at @aqueerpride 🥰 ⬇️ Buy my pins ⬇️",
-    followersCount: 6941,
-    followingCount: 1890,
-    fullName: "Abhijeet 🇮🇳👳🏽👳🏾‍♀️👳🏽🇮🇳",
-    instagramID: "207167707",
-    mutualFollowersCount: 24,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/97d86e71a1dc02c7f6df8ec84a440564/5D4BE9ED/t51.2885-19/s320x320/51739974_2575683252506804_3605265732322983936_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 469,
-    profileName: "bon_abhijeet",
-    website: "https://abhijeet.bigcartel.com/",
-    timestamp: "2019-04-01T04:51:59.084Z"
-  },
-  {
-    query: "https://www.instagram.com/kenziecoulee",
-    profileUrl: "https://www.instagram.com/kenziecoulee/",
-    bio: "actual goddess / non-playable character / reptilian humanoid Maison Couleé 👑 👩‍👧‍👧✨ BOOK : kenziecoulee@gmail.com Venmo : @kenziecoulee",
-    followersCount: 12525,
-    followingCount: 1685,
-    fullName: "Ҝ乇几乙丨乇 🐲 匚ㄖㄩㄥ乇乇",
-    instagramID: "17991071",
-    mutualFollowersCount: 21,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/ac1eec2cedf917e701916bdefa480e67/5D35788B/t51.2885-19/s320x320/50574467_247231406153269_5896326885738020864_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 2081,
-    profileName: "kenziecoulee",
-    timestamp: "2019-04-01T04:52:03.161Z"
-  },
-  {
-    query: "https://www.instagram.com/_khloepark",
-    profileUrl: "https://www.instagram.com/_khloepark/",
-    bio: "📍 Chicago 🌟 Socialite 👸🏽 Homecoming Queen 2012 🎀 The girl next door... that does drag",
-    followersCount: 1816,
-    followingCount: 586,
-    fullName: "Khloe Park",
-    instagramID: "6907315573",
-    mutualFollowersCount: 13,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/8e3b398d97298131447643dabef7d1d0/5D431EDD/t51.2885-19/s320x320/52442028_1259707284177485_6217925455517843456_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 170,
-    profileName: "_khloepark",
-    timestamp: "2019-04-01T04:52:09.011Z"
-  },
-  {
-    query: "https://www.instagram.com/mimimarks11",
-    profileUrl: "https://www.instagram.com/mimimarks11/",
-    bio: "Showgirl/Entertainer from Chicago💖! #girlslikeus #transisbeautiful #MIQ2005 🦄 Snapchat/Twitter: @mimimarks11",
-    followersCount: 12415,
-    followingCount: 2354,
-    fullName: "Mimi Marks",
-    instagramID: "39542483",
-    mutualFollowersCount: 11,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/9d2953c03ca1ca6dc5f163cfa6dd564c/5D4E283E/t51.2885-19/s320x320/29095940_293625631169774_6354641656188239872_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1491,
-    profileName: "mimimarks11",
-    timestamp: "2019-04-01T04:52:13.947Z"
-  },
-  {
-    query: "https://www.instagram.com/nayshalopez",
-    profileUrl: "https://www.instagram.com/nayshalopez/",
-    bio: "RPDR S8 💄 #TheBeauty 💅🏽 Miss Continental 13/14 👑 📧 nayshalopez@gmail.com for bookings... ❤💋",
-    followersCount: 91497,
-    followingCount: 3562,
-    fullName: "Naysha Lopez",
-    instagramID: "481078287",
-    verified: "Verified",
-    mutualFollowersCount: 32,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/38eb40ebda7794c98b6b60d536faf4fc/5D3C2A78/t51.2885-19/s320x320/46411704_1201154766715423_484855774258921472_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 726,
-    profileName: "nayshalopez",
-    timestamp: "2019-04-01T04:52:19.510Z"
-  },
-  {
-    query: "https://www.instagram.com/fayludes",
-    profileUrl: "https://www.instagram.com/fayludes/",
-    bio: "💊Chicago’s Drag Disco Biscuit💊 ✨Host @maryschicago✨ Tues: Let’s Make a Diva 1st Sun: Divas Brunch 2nd Fri: Let’s Make a Diva 4th Fri: HypeHerHour 🧡🌱",
-    followersCount: 4420,
-    followingCount: 2327,
-    fullName: "Fāy Ludes",
-    instagramID: "5458537511",
-    mutualFollowersCount: 10,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/ea4ca467d510636390343c37dcf7820d/5D3B7C8F/t51.2885-19/s320x320/43143904_553440405077552_6966782853598150656_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 244,
-    profileName: "fayludes",
-    timestamp: "2019-04-01T04:52:25.186Z"
-  },
-  {
-    query: "https://www.instagram.com/dianatunnel13",
-    profileUrl: "https://www.instagram.com/dianatunnel13/",
-    bio: "Chicago's backwoods Barbie For bookings, email dianatunnel13@gmail.com",
-    followersCount: 1066,
-    followingCount: 1107,
-    fullName: "Diana Tunnel",
-    instagramID: "240207515",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 4,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/0ecb820068c81915ee419a18fe80578e/5D3CFAE3/t51.2885-19/s320x320/47693299_276593406371651_5843873313440399360_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1383,
-    profileName: "dianatunnel13",
-    timestamp: "2019-04-01T04:52:30.089Z"
-  },
-  {
-    query: "https://www.instagram.com/chgodarla",
-    profileUrl: "https://www.instagram.com/chgodarla/",
-    bio: "The Bingo Hostess at Charlie's Chicago",
-    followersCount: 423,
-    followingCount: 696,
-    fullName: "Darla Dae",
-    instagramID: "3558952197",
-    mutualFollowersCount: 0,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/640557d74515923d83777a4f114803e1/5D37D05B/t51.2885-19/s150x150/13740926_1730091973931368_1603088894_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 108,
-    profileName: "chgodarla",
-    timestamp: "2019-04-01T04:52:36.028Z"
-  },
-  {
-    query: "https://www.instagram.com/alexandrea.diamond",
-    profileUrl: "https://www.instagram.com/alexandrea.diamond/",
-    bio: "| Show Director • Charlies Chicago • | Miss Chicago Continental 2018-2019 | | Miss Latina Continental 2018-2019 | | Miss Primavera | Miss GLK |",
-    followersCount: 3483,
-    followingCount: 1193,
-    fullName: "Alexandrea Diamond 🇵🇷 💃🏽",
-    instagramID: "52699225",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 1,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/c2ff99efc34d0a4500892a3dd58e354c/5D382B26/t51.2885-19/s320x320/40661544_264945167683438_938728822675603456_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 125,
-    profileName: "alexandrea.diamond",
-    timestamp: "2019-04-01T04:52:42.061Z"
-  },
-  {
-    query: "https://www.instagram.com/vickyypop",
-    profileUrl: "https://www.instagram.com/vickyypop/",
-    bio: "✨Same Girl, Same✨ Host of #POPOFF &amp; #POPular at Charlie's Chicago EVERY FRIDAY &amp; SATURDAY NIGHT! 📸 youtube.com/vickyypop",
-    followersCount: 17233,
-    followingCount: 1377,
-    fullName: "🌮Veronica Pop🌮",
-    instagramID: "248524899",
-    businessAccount: "Business Account",
-    businessCategory: "Creators &amp; Celebrities",
-    mutualFollowersCount: 17,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/99d5995e5b8c89c20c368d26ce948cfe/5D34BA04/t51.2885-19/s320x320/52173643_388723338611022_7452198378059857920_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1436,
-    profileName: "vickyypop",
-    website: "http://www.veronicapop.threadless.com/",
-    timestamp: "2019-04-01T04:52:46.496Z"
-  },
-  {
-    query: "https://www.instagram.com/chamilla_foxx",
-    profileUrl: "https://www.instagram.com/chamilla_foxx/",
-    bio: "HBIC at @styledbychamilla 💇🏽‍♀️ Host of @sundaysocialchi💃🏽 2 X's in my name cause I'm extra af 😜",
-    followersCount: 5300,
-    followingCount: 1961,
-    fullName: "Chamilla Foxx 🏳️‍🌈🇲🇽",
-    instagramID: "231551770",
-    mutualFollowersCount: 16,
-    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/9ea2e8ba35934147277db7f6b34cd28a/5D503995/t51.2885-19/s320x320/53843332_2074262452864071_1373758445110427648_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
-    postsCount: 1367,
-    profileName: "chamilla_foxx",
-    website: "https://www.youtube.com/user/envyrc",
-    timestamp: "2019-04-01T04:52:51.131Z"
-  }
-]
-
+];
 
 module.exports = {
   bars,
   queens,
-  queensInsta
 };

--- a/mod-2/whateverly/1901/jacobogart.js
+++ b/mod-2/whateverly/1901/jacobogart.js
@@ -1,0 +1,1960 @@
+const bars = [
+  {
+    "name": "Roscoe's Tavern",
+    "address": "3356 N Halsted St, Chicago, IL 60657",
+    "phone": "(773) 281-3355",
+    "website": "https://roscoes.com/",
+    "facebook": "https://www.facebook.com/RoscoesTavern",
+    "instagram": "https://www.instagram.com/roscoestavern/",
+    "twitter": "https://twitter.com/Roscoestavern",
+    "shows": [
+      {
+        "title": "Roscoe's Drag Race",
+        "category": "competition",
+        "dayOfWeek": "Tuesday",
+        "reoccuring": true,
+        "frequency": "weekly"
+      },
+      {
+        "title": "Roscoe’s RPDR S11 Viewing Party",
+        "category": "viewing party",
+        "dayOfWeek": "Thursday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "host": "T Rex",
+        "notes": "Doors open at 5PM. Seating begins at 6PM. New episode begins at 8PM. No Cover!"
+      },
+      {
+        "title": "XYZ",
+        "category": "drag show",
+        "dayOfWeek": "Sunday",
+        "reoccuring": true,
+        "frequency": "monthly",
+        "host": "T Rex",
+        "lineups": {
+          "04/07/19": [
+            "Bambi Banks Couleé",
+            "Denali",
+            "Ashley Malone",
+            "Kat Sass",
+            "Keri Traid",
+            "Tenderoni"
+          ]
+        },
+        "notes": "Bringing Generations X, Y, & Z together to celebrate their shared love of the music from the mid 1990’s through the early 2000’s with DJ Ron!"
+      }
+    ]
+  },
+  {
+    "name": "Berlin Nightclub",
+    "address": "954 W Belmont Ave, Chicago, IL 60657",
+    "phone": "(773) 348-4975",
+    "website": "https://berlinchicago.com/",
+    "facebook": "https://www.facebook.com/BerlinNightclub/",
+    "instagram": "https://www.instagram.com/berlinnightclub/",
+    "twitter": "https://twitter.com/BerlinNightclub",
+    "shows": [
+      {
+        "title": "Squad Goals",
+        "category": "drag show",
+        "dayOfWeek": "Monday",
+        "reoccuring": true,
+        "frequency": "1st Monday",
+        "startTime": 2200,
+        "lineups": {
+          "04/01/19": [
+            "Alex Kay",
+            "Blondebenét",
+            "Logan Zass",
+            "Joonage À Trois"
+          ]
+        },
+        "notes": "3 Year Anniversary! Join us for a Small Tribute to the Memories we've made Throughout the Years"
+      },
+      {
+        "title": "SLAY: Afterbirth",
+        "category": "competition",
+        "dayOfWeek": "Wednesday",
+        "reoccuring": false,
+        "frequency": null,
+        "startTime": 2200,
+        "lineups": {
+          "04/03/19": [
+            "Lady Ivory",
+            "Claire Voyant",
+            "Kat Sass",
+            "Tenderoni",
+            "Masha Potato",
+            "Siichele"
+          ]
+        }
+      },
+      {
+        "title": "Drag Matinee",
+        "category": "drag show",
+        "dayOfWeek": "Saturday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2230,
+        "host": "T Rex",
+        "lineups": {
+          "04/06/19": [
+            "Laila McQueen",
+            "Sasha Belle",
+            "Chasity Marie",
+            "Lucy Stoole",
+            "Aunty Chan",
+            "Savannah Westbrooke",
+            "Aura Mayari"
+          ],
+          "04/13/19": [
+            "Ophelia Belle",
+            "Monica Beverly Hillz",
+            "Imp Queen",
+            "Denali",
+            "Irregular Girl",
+            "Tiffany Diamond",
+            "Raven Samore"
+          ],
+          "04/20/19": [
+            "Jasmine Masters",
+            "The Princess",
+            "Julia Starr",
+            "Tracey Ottomey",
+            "Cleo Pockalipps",
+            "Kahmora Hall",
+            "Ashley Malone"
+          ],
+          "04/27/19": [
+            "Serena Cha Cha",
+            "Gilda Wabbit",
+            "Umi Naughty",
+            "Zsa Zsa Gabortion",
+            "Khloe Park",
+            "Bambi Banks Couleé",
+            "Elektra Del Rio"
+          ]
+        }
+      },
+      {
+        "title": "Plot Twist",
+        "category": "drag show",
+        "dayOfWeek": "Monday",
+        "reoccuring": true,
+        "frequency": "3rd Mondau",
+        "startTime": 2230,
+        "host": "T Rex",
+        "lineups": {
+          "04/15/19": []
+        },
+        "notes": "THE HALF-TIME SHOW: Surprises, Reveals, and OMG Moments! Bring the Drama and Snatch the Gig!"
+      },
+      {
+        "title": "Crash Landing",
+        "category": "competition",
+        "dayOfWeek": "Monday",
+        "reoccuring": true,
+        "frequency": "2nd and 4th Mondays",
+        "startTime": 2200,
+        "host": [
+          "T Rex",
+          "Nico"
+        ],
+        "notes": "A 3 Round Competition for Drag Queens, Bio Queens, Kings, and Straight Up Aliens"
+      }
+    ]
+  },
+  {
+    "name": "Sidetrack The Video Bar",
+    "address": "3349 N Halsted St Chicago, IL  60657",
+    "phone": "(773) 477-9189",
+    "website": "https://www.sidetrackchicago.com/",
+    "facebook": "https://www.facebook.com/SidetrackBar",
+    "instagram": "https://www.instagram.com/sidetrackbar/",
+    "twitter": "https://twitter.com/sidetrackbar",
+    "shows": [
+      {
+        "title": "Chicago's RuPaul's Drag Race Season 11 Viewing Party",
+        "category": "viewing party",
+        "dayOfWeek": "Thursday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2000,
+        "host": [
+          "Dixie Lynn Cartwright",
+          "DiDa Ritz"
+        ]
+      },
+      {
+        "title": "Shantay You Stay!",
+        "category": "competition",
+        "dayOfWeek": "Thursday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2200,
+        "host": [
+          "Dixie Lynn Cartwright",
+          "Danika Bone't"
+        ]
+      },
+      {
+        "title": "Dixie Wins A Talent Show",
+        "category": "competition",
+        "dayOfWeek": "Tuesday",
+        "reoccuring": true,
+        "frequency": "last",
+        "startTime": 2130,
+        "host": [
+          "Dixie Lynn Cartwright",
+          "Alexis Bevels"
+        ],
+        "notes": "You are the judge for who wins (well, Dixie says she's the winner, but we'll see about that) so join us to cheer on your faves."
+      }
+    ]
+  },
+  {
+    "name": "Scarlet Bar",
+    "address": "3320 N Halsted St, Chicago, IL 60657",
+    "phone": "(773) 348-1053",
+    "website": "https://www.scarletchicago.com/",
+    "facebook": "https://www.facebook.com/Scarletbar/",
+    "instagram": "https://www.instagram.com/scarletchicago/",
+    "twitter": "https://twitter.com/scarletchicago",
+    "shows": [
+      {
+        "title": "SingAlong! “Mary Poppins Returns” Viewing Party!",
+        "facebookEvent": "https://www.facebook.com/events/2347284362197354/",
+        "category": "drag show",
+        "dayOfWeek": "Wednesday",
+        "reoccuring": false,
+        "frequency": null,
+        "startTime": 2000,
+        "host": [
+          "Abhijeet",
+          "Irregular Girl"
+        ],
+        "notes": "Starting at 8:30pm we will be playing /“Mary Poppins Returns/” and afterwards the SingAlong event will begin! Also, at the don’t miss our new Disney themed Drag Show!"
+      },
+      {
+        "title": "Friday's with Kenzie Coulee",
+        "category": "dance party",
+        "dayOfWeek": "Friday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2300,
+        "host": "Kenzie Coulee"
+      },
+      {
+        "title": "Frat Night",
+        "category": "dance party",
+        "dayOfWeek": "Thursday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2200,
+        "host": "Khloe Park"
+      }
+    ]
+  },
+  {
+    "name": "Hydrate",
+    "address": "3458 N Halsted St, Chicago, IL 60657",
+    "phone": "(773) 975-9244",
+    "website": "http://www.hydratechicago.com/",
+    "facebook": "https://www.facebook.com/hydratechicago/",
+    "instagram": "https://www.instagram.com/hydrate.nightclub/",
+    "twitter": "https://twitter.com/HydrateChicago",
+    "shows": [
+      {
+        "title": "Ruffy’s Lipstick & Mascara",
+        "category": "drag show",
+        "dayOfWeek": "Monday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2300,
+        "host": "Mz. Ruff ‘N Stuff",
+        "notes": "Monday nights get an upgrade with a show unlike any you’ve seen before!"
+      },
+      {
+        "title": "Honeys on Halsted",
+        "category": "drag show",
+        "dayOfWeek": "Wednesday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2300,
+        "host": [
+          "Mz. Ruff ‘N Stuff",
+          "Mimi Marks"
+        ],
+        "notes": "With weekly guest performers!"
+      },
+      {
+        "title": "Beauties & Beaus",
+        "website": "http://beautiesandbeaus.com/",
+        "category": "drag show",
+        "dayOfWeek": [
+          "Friday",
+          "Saturday"
+        ],
+        "reoccuring": true,
+        "frequency": "semi-weekly",
+        "startTime": 2115,
+        "host": [
+          "Naysha Lopez",
+          "Mz. Ruff ‘N Stuff"
+        ],
+        "notes": "With weekly guest performers!"
+      }
+    ]
+  },
+  {
+    "name": "Hamburger Mary's",
+    "address": "5400 N Clark St, Chicago, IL 60640",
+    "phone": "(773) 784-6969",
+    "website": "https://www.hamburgermarys.com/chicago/",
+    "facebook": "https://www.facebook.com/maryschicago/",
+    "instagram": "https://www.instagram.com/maryschicago/",
+    "twitter": "https://twitter.com/MarysChicago?lang=en",
+    "shows": [
+      {
+        "title": "Charity HamBingo Mary’s",
+        "website": "https://www.hamburgermarys.com/chicago/events/event/charity-hambingo-marys/",
+        "category": "bingo",
+        "dayOfWeek": "Monday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2000,
+        "host": "Granny Mattress",
+        "notes": "Guests are asked to make a $15 donation to play all night (10 games, three chances to win each game)."
+      },
+      {
+        "title": "Let’s Make a DIVA!",
+        "website": "https://www.hamburgermarys.com/chicago/events/event/lets-make-a-diva-2/",
+        "category": "competition",
+        "dayOfWeek": "Tuesday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2000,
+        "host": "Fay Ludes",
+        "notes": "We start off with 6-8 contestants who compete for the chance to come back the next week. The bi-weekly winner gets a booking at one of Mary’s “Dining with the Divas” shows "
+      },
+      {
+        "title": "Drag Race at Mary's",
+        "category": "viewing party",
+        "dayOfWeek": "Thrusday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2000,
+        "host": "Diana Tunnel"
+      },
+      {
+        "title": "Charity HamBingo Mary’s",
+        "website": "https://www.hamburgermarys.com/chicago/events/event/charity-hambingo-marys/",
+        "category": "bingo",
+        "dayOfWeek": "Sunday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 1900,
+        "host": "Alexis Bevels",
+        "notes": "Guests are asked to make a $15 donation to play all night (10 games, three chances to win each game)."
+      },
+      {
+        "title": "Dining With the Divas! (Friday)",
+        "website": "https://www.hamburgermarys.com/chicago/events/event/dining-with-the-divas-2/",
+        "category": "drag show",
+        "dayOfWeek": "Friday",
+        "reoccuring": true,
+        "frequency": "semi-weekly",
+        "startTime": [
+          1930,
+          2130
+        ],
+        "notes": "Seating will begin about a half hour before showtime.  Shows run about an hour."
+      },
+      {
+        "title": "Dining With the Divas! (Saturday)",
+        "website": "https://www.hamburgermarys.com/chicago/events/event/dining-with-divas/",
+        "category": "drag show",
+        "dayOfWeek": "Saturday",
+        "reoccuring": true,
+        "frequency": "semi-weekly",
+        "startTime": [
+          1930,
+          2130
+        ],
+        "notes": "Seating will begin about a half hour before showtime.  Shows run about an hour."
+      },
+      {
+        "title": "Divas Brunch",
+        "website": "https://www.hamburgermarys.com/chicago/events/event/divas-brunch-with-bottomless-mimosas/",
+        "category": "drag show",
+        "dayOfWeek": "Sunday",
+        "reoccuring": true,
+        "frequency": "semi-weekly",
+        "startTime": [
+          1100,
+          1300
+        ],
+        "notes": "Seating begins at 10:15am for the first show and 12:15pm for the second show."
+      }
+    ]
+  },
+  {
+    "name": "Kit Kat Lounge & Supper Club",
+    "address": "3700 N Halsted St, Chicago, IL 60613",
+    "phone": "(773) 525-1111",
+    "website": "http://www.kitkatchicago.com/",
+    "facebook": "https://www.facebook.com/KitKatLoungeAndSupperClub/",
+    "instagram": "https://www.instagram.com/kitkatlounge/?hl=en",
+    "twitter": "https://twitter.com/kitkatlounge?lang=en",
+    "shows": [
+      {
+        "title": "Kit Kat's Nightly Show",
+        "category": "drag show",
+        "dayOfWeek": [
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday"
+        ],
+        "reoccuring": true,
+        "frequency": "nightly",
+        "startTime": 1830,
+        "notes": "Kit Kat's nightly shows run every 20 minutes starting at 6.30pm through midnight."
+      }
+    ]
+  },
+  {
+    "name": "Charlie's Chicago",
+    "address": "3726 N Broadway, Chicago, IL 60613",
+    "phone": "(773) 871-8887",
+    "notes": "Western-themed Boystown bar & dance club with drag shows, karaoke, bingo & late-night hours.",
+    "website": "http://www.charlieschicago.com/",
+    "facebook": "https://www.facebook.com/charlieschicago/",
+    "instagram": "https://www.instagram.com/charlieschicagobar/",
+    "twitter": "https://twitter.com/CharliesBarChi",
+    "shows": [
+      {
+        "title": "Sing-Sational Sunday!",
+        "category": "karaoke",
+        "dayOfWeek": "Sunday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 1900,
+        "host": "Danika Bone't"
+      },
+      {
+        "title": "Double 'D' Bingo",
+        "category": "bingo",
+        "dayOfWeek": "Monday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2100,
+        "host": [
+          "Darla Dae", 
+          "Danika Bone't"
+        ]
+      },
+      {
+        "title": "Twisted Tuesdays",
+        "category": "drag show",
+        "dayOfWeek": "Tuesday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2330,
+        "host": "Danika Bone't",
+        "notes": "Special guests weekly"
+      },
+      {
+        "title": "Throwback Thursdays",
+        "category": "drag show",
+        "dayOfWeek": "Thursday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2200,
+        "host": "Alexandrea Diamond",
+        "notes": "1st Week Of The Month: 80’s. 2nd Week Of The Month: 90’s. 3rd Week Of The Month: Early 2000’s. 4th Week Of the Month: Body Beautiful."
+      },
+      {
+        "title": "Veronica's POP OFF!",
+        "category": "drag show",
+        "dayOfWeek": "Friday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2300,
+        "host": "Veronica Pop"
+      },
+      {
+        "title": "#POPular",
+        "category": "competition",
+        "dayOfWeek": "Satruday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2230,
+        "host": [
+          "Veronica Pop",
+          "Tiffany Diamond"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Replay Lakeview",
+    "address": "3439 N Halsted St, Chicago, IL 60657",
+    "phone": "(773) 661-9632",
+    "notes": "Vintage video games entertain patrons of this funky arcade bar with beer, bourbon & cocktails.",
+    "website": "http://www.replaylakeview.com/",
+    "facebook": "https://www.facebook.com/ReplayLakeview/",
+    "instagram": "https://www.instagram.com/replaylakeview/",
+    "twitter": "https://twitter.com/replaylakeview?lang=en",
+    "shows": [
+      {
+        "title": "Killer Babes",
+        "category": "drag show",
+        "dayOfWeek": "Thursday",
+        "reoccuring": true,
+        "frequency": "2nd Thrusday",
+        "startTime": 2200,
+        "host": "Lady Ivory",
+        "notes": "$5 at the door"
+      }
+    ]
+  },
+  {
+    "name": "Smartbar",
+    "address": "3730 N Clark St, Chicago, IL 60613",
+    "phone": "(773) 549-4140",
+    "notes": "This lively, hip nightspot features DJs spinning techno dance music, beer & cocktails.",
+    "website": "https://smartbarchicago.com/",
+    "facebook": "https://www.facebook.com/smartbarchicago",
+    "instagram": "https://www.instagram.com/smartbarchicago/",
+    "twitter": "https://twitter.com/smartbar",
+    "shows": [
+      {
+        "title": "Queen!",
+        "category": "drag show",
+        "dayOfWeek": "Sunday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2200,
+        "host": "Lucy Stoole"
+      }
+    ]
+  },
+  {
+    "name": "Splash Chicago",
+    "address": "3339 N Halsted St, Chicago, IL 60657",
+    "phone": "(773) 904-7338",
+    "website": "https://splash-chicago.com/",
+    "facebook": "https://www.facebook.com/SplashChicagoIL/",
+    "instagram": "https://www.instagram.com/splash_chicago/",
+    "twitter": "https://twitter.com/Splash_Chicago",
+    "shows": [
+      {
+        "title": "TENS",
+        "category": "competition",
+        "dayOfWeek": "Monday",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 2200,
+        "host": "Elektra Del Rio",
+        "notes": "This 10 week competition is about to take you on the ride of your life featuring: guest judges, weekly challenges, prizes, lip sync for your life battles and audience chosen eliminations."
+      }
+    ]
+  },
+  {
+    "name": "Meeting House Tavern",
+    "address": "5025 N Clark St, Chicago, IL 60640",
+    "phone": "(773) 696-4211",
+    "website": "http://www.meetinghousetavern.com/",
+    "facebook": "https://www.facebook.com/MeetingHouseChi",
+    "instagram": "https://www.instagram.com/meetinghousetavernchi/",
+    "twitter": "https://twitter.com/meetinghousechi",
+    "shows": [
+      {
+        "title": "Sunday Social",
+        "category": "drag show",
+        "dayOfWeek": "Sudnay",
+        "reoccuring": true,
+        "frequency": "weekly",
+        "startTime": 1400,
+        "host": "Chamilla Foxx"
+      }
+    ]
+  }
+],
+
+const queens = [
+  {
+    "name": "T Rex",
+    "instagram": "https://www.instagram.com/trexinchicago/?hl=en",
+    "facebook": "https://www.facebook.com/trannika",
+    "twitter": "https://twitter.com/trexinchicago?lang=en",
+    "shows": [
+      "Roscoe’s RPDR S11 Viewing Party",
+      "XYZ",
+      "Drag Matinee",
+      "Crash Landing"
+    ]
+  },
+  {
+    "name": "Friday Lay",
+    "instagram": "https://www.instagram.com/fridalay69/",
+    "facebook": "https://www.facebook.com/fridalay",
+    "twitter": "https://twitter.com/fridalay?lang=en",
+    "shows": [
+      "Roscoe's Drag Race"
+    ]
+  },
+  {
+    "name": "Bambi Banks Couleé",
+    "instagram": "https://www.instagram.com/bambi.banks/?hl=en",
+    "facebook": "https://www.facebook.com/bambi.banks.372",
+    "twitter": "https://twitter.com/itsbambibanks?lang=en",
+    "shows": [
+      "XYZ",
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Denali",
+    "instagram": "https://www.instagram.com/denali_._/",
+    "shows": [
+      "XYZ",
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Ashley Malone",
+    "instagram": "https://www.instagram.com/msmalone28/?hl=en",
+    "facebook": "https://www.facebook.com/ashley.malone.14",
+    "twitter": "https://twitter.com/msmalone28?lang=en",
+    "shows": [
+      "XYZ",
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Kat Sass",
+    "instagram": "https://www.instagram.com/kat.sass/?hl=en",
+    "facebook": "https://www.facebook.com/ihatekatsass",
+    "twitter": "https://twitter.com/ihatekatsass?lang=en",
+    "shows": [
+      "XYZ",
+      "SLAY: Afterbirth"
+    ]
+  },
+  {
+    "name": "Keri Traid",
+    "instagram": "https://www.instagram.com/iamkeritraid/?hl=en",
+    "shows": [
+      "XYZ"
+    ]
+  },
+  {
+    "name": "Tenderoni",
+    "instagram": "https://www.instagram.com/tenderoni88/?hl=en",
+    "twitter": "https://twitter.com/tender_oni?lang=en",
+    "shows": [
+      "XYZ",
+      "SLAY: Afterbirth"
+    ]
+  },
+  {
+    "name": "Alex Kay",
+    "instagram": "https://www.instagram.com/butchqween/?hl=en",
+    "twitter": "https://twitter.com/AlexKayJustOk",
+    "shows": [
+      "Squad Goals"
+    ]
+  },
+  {
+    "name": "Blondebenét",
+    "instagram": "https://www.instagram.com/blondebenet/?hl=en",
+    "twitter": "https://twitter.com/blonde_benet",
+    "facebook": "https://www.facebook.com/blondebenet",
+    "shows": [
+      "Squad Goals"
+    ]
+  },
+  {
+    "name": "Logan Zass",
+    "instagram": "https://www.instagram.com/loganzass/?hl=en",
+    "shows": [
+      "Squad Goals"
+    ]
+  },
+  {
+    "name": "Joonage À Trois",
+    "instagram": "https://www.instagram.com/joonageatrois/?hl=en",
+    "shows": [
+      "Squad Goals"
+    ]
+  },
+  {
+    "name": "Lady Ivory",
+    "instagram": "https://www.instagram.com/theladyivory/?hl=en",
+    "facebook": "https://www.facebook.com/TheLadyIvory/",
+    "shows": [
+      "SLAY: Afterbirth",
+      "Killer Babes"
+    ]
+  },
+  {
+    "name": "Claire Voyant",
+    "instagram": "https://www.instagram.com/claire.voyant.queen/?hl=en",
+    "twitter": "https://twitter.com/_claire_voyant",
+    "facebook": "https://www.facebook.com/claire.voyant.queen",
+    "shows": [
+      "SLAY: Afterbirth"
+    ]
+  },
+  {
+    "name": "Masha Potato",
+    "instagram": "https://www.instagram.com/crinklecutqueen/?hl=en",
+    "twitter": "https://twitter.com/crinklecutqueen",
+    "shows": [
+      "SLAY: Afterbirth"
+    ]
+  },
+  {
+    "name": "Siichele",
+    "instagram": "https://www.instagram.com/siichele/?hl=en",
+    "twitter": "https://twitter.com/siichele?lang=en",
+    "shows": [
+      "SLAY: Afterbirth"
+    ]
+  },
+  {
+    "name": "Laila McQueen",
+    "instagram": "https://www.instagram.com/misslailamcqueen/?hl=en",
+    "twitter": "https://twitter.com/lailamcqueen?lang=en",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Sasha Belle",
+    "instagram": "https://www.instagram.com/sashabelley/?hl=en",
+    "twitter": "https://twitter.com/sashabelle3?lang=en",
+    "facebook": "https://www.facebook.com/Sasha-Belle-1457446307864946/",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Chasity Marie",
+    "instagram": "https://www.instagram.com/_chasitymarie_/?hl=en",
+    "twitter": "https://twitter.com/_chasitymarie_?lang=en",
+    "facebook": "https://www.facebook.com/TheChasityMarie/",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Lucy Stoole",
+    "instagram": "https://www.instagram.com/tyislucystoole/",
+    "twitter": "https://twitter.com/lucystoole?lang=en",
+    "facebook": "https://www.facebook.com/lucystooleisaslut",
+    "shows": [
+      "Drag Matinee",
+      "Queen!"
+    ]
+  },
+  {
+    "name": "Aunty Chan",
+    "instagram": "https://www.instagram.com/aunty_chan/?hl=en",
+    "twitter": "https://twitter.com/aunty_chan?lang=en",
+    "facebook": "https://www.facebook.com/auntycherrychan",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Savannah Westbrooke",
+    "instagram": "https://www.instagram.com/savannahwestbrooke/?hl=en",
+    "twitter": "https://twitter.com/sbvancartier?lang=en",
+    "facebook": "https://www.facebook.com/simplybeautifull26",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Aura Mayari",
+    "instagram": "https://www.instagram.com/auramayari/?hl=en",
+    "facebook": "https://www.facebook.com/AuraMayari08",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Nico",
+    "instagram": "https://www.instagram.com/nicozworld/?hl=en",
+    "twitter": "https://twitter.com/nicozworld?lang=en",
+    "facebook": "https://www.facebook.com/nicobombshell/",
+    "shows": [
+      "Crash Landing"
+    ]
+  },
+  {
+    "name": "Ophelia Belle",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Monica Beverly Hillz",
+    "instagram": "https://www.instagram.com/monicabhillz/?hl=en",
+    "twitter": "https://twitter.com/MonicaBHillz",
+    "facebook": "https://www.facebook.com/MonicaBeverlyHillz/",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Imp Queen",
+    "instagram": "https://www.instagram.com/imp_kid/?hl=en",
+    "twitter": "https://twitter.com/imp_kid?lang=en",
+    "facebook": "https://www.facebook.com/darrenbarrere",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Irregular Girl",
+    "instagram": "https://www.instagram.com/imirregulargirl/?hl=en",
+    "shows": [
+      "Drag Matinee",
+      "SingAlong! /“Mary Poppins Returns/” Viewing"
+    ]
+  },
+  {
+    "name": "Tiffany Diamond",
+    "instagram": "https://www.instagram.com/liketotallytiffany/?hl=en",
+    "twitter": "https://twitter.com/liketotallytiff?lang=en",
+    "facebook": "https://www.facebook.com/liketotallytiffany",
+    "shows": [
+      "Drag Matinee",
+      "#POPular"
+    ]
+  },
+  {
+    "name": "Raven Samore",
+    "facebook": "https://www.facebook.com/MissRavenSamore",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Jasmine Masters",
+    "instagram": "https://www.instagram.com/msjasminemasters/?hl=en",
+    "twitter": "https://twitter.com/Jasminejmasters?lang=en",
+    "facebook": "https://www.facebook.com/msjasminemasters/",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "The Princess",
+    "instagram": "https://www.instagram.com/thedragprincess/?hl=en",
+    "twitter": "https://twitter.com/thedragprincess?lang=en",
+    "facebook": "https://www.facebook.com/TheDragPrincess/",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Julia Starr",
+    "instagram": "https://www.instagram.com/julia_starr__/",
+    "facebook": "https://www.facebook.com/Thejuliastarr/",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Tracey Ottomey",
+    "instagram": "https://www.instagram.com/traceyottomey/",
+    "twitter": "https://twitter.com/traceyottomey?lang=en",
+    "facebook": "https://www.facebook.com/tracey.ottomey",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Cleo Pockalipps",
+    "instagram": "https://www.instagram.com/cleopockalipps/?hl=en",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Kahmora Hall",
+    "instagram": "https://www.instagram.com/kahmorahall/",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Dixie Lynn Cartwright",
+    "instagram": "https://www.instagram.com/dixielynncartwright/?hl=en",
+    "twitter": "https://twitter.com/thedixielynn?lang=en",
+    "facebook": "https://www.facebook.com/DixieLynnCartwright/",
+    "shows": [
+      "Chicago's RuPaul's Drag Race Season 11 Viewing Party",
+      "Shantay You Stay!",
+      "Dixie Wins A Talent Show"
+    ]
+  },
+  {
+    "name": "DiDa Ritz",
+    "instagram": "https://www.instagram.com/didaswag/?hl=en",
+    "facebook": "https://www.facebook.com/DiDaHallRitz",
+    "shows": [
+      "Chicago's RuPaul's Drag Race Season 11 Viewing Party"
+    ]
+  },
+  {
+    "name": "Danika Bone't",
+    "instagram": "https://www.instagram.com/danikabonet/",
+    "twitter": "https://twitter.com/danikastanikan",
+    "facebook": "https://www.facebook.com/DanikaBonet",
+    "shows": [
+      "Shantay You Stay!",
+      "Sing-Sational Sunday!",
+      "Double 'D' Bingo",
+      "Twisted Tuesdays"
+    ]
+  },
+  {
+    "name": "Alexis Bevels",
+    "instagram": "https://www.instagram.com/alexisbevels/?hl=en",
+    "twitter": "https://twitter.com/AlexisBevels",
+    "facebook": "https://www.facebook.com/alexis.bevels",
+    "shows": [
+      "Dixie Wins A Talent Show",
+      "Charity HamBingo Mary’s"
+    ]
+  },
+  {
+    "name": "Serena Cha Cha",
+    "instagram": "https://www.instagram.com/myron.morgan/?hl=en",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Gilda Wabbit",
+    "instagram": "https://www.instagram.com/gildawabbit/?hl=en",
+    "twitter": "https://twitter.com/gildawabbit?lang=en",
+    "facebook": "https://www.facebook.com/GildaWabbit/",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Umi Naughty",
+    "instagram": "https://www.instagram.com/uminaughty/",
+    "twitter": "https://twitter.com/theuminaughty",
+    "facebook": "https://www.facebook.com/umiinaughttyy/",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Zsa Zsa Gabortion",
+    "instagram": "https://www.instagram.com/missgabortion/",
+    "twitter": "https://twitter.com/missgabortion",
+    "facebook": "https://www.facebook.com/missgabortionif.unasty",
+    "shows": [
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Elektra Del Rio",
+    "instagram": "https://www.instagram.com/elektradelrio/?hl=en",
+    "twitter": "https://twitter.com/elektradelrio?lang=en",
+    "facebook": "https://www.facebook.com/ElektraDelRio",
+    "shows": [
+      "Drag Matinee",
+      "TENS"
+    ]
+  },
+  {
+    "name": "Abhijeet",
+    "instagram": "https://www.instagram.com/bon_abhijeet/?hl=en",
+    "twitter": "https://twitter.com/bon_abhijeet",
+    "facebook": "https://www.facebook.com/BonAbhijeet",
+    "shows": [
+      "SingAlong! “Mary Poppins Returns” Viewing Party!"
+    ]
+  },
+  {
+    "name": "Kenzie Coulee",
+    "instagram": "https://www.instagram.com/kenziecoulee/n",
+    "shows": [
+      "Friday's with Kenzie Coulee"
+    ]
+  },
+  {
+    "name": "Khloe Park",
+    "instagram": "https://www.instagram.com/_khloepark/",
+    "twitter": "https://twitter.com/_khloepark",
+    "facebook": "https://www.facebook.com/khloe.park.90",
+    "shows": [
+      "Frat Night",
+      "Drag Matinee"
+    ]
+  },
+  {
+    "name": "Mz. Ruff ‘N Stuff",
+    "shows": [
+      "Ruffy’s Lipstick & Mascara",
+      "Honeys on Halsted",
+      "Beauties & Beaus"
+    ]
+  },
+  {
+    "name": "Mimi Marks",
+    "instagram": "https://www.instagram.com/mimimarks11/?hl=en",
+    "twitter": "https://twitter.com/mimimarks11?lang=en",
+    "facebook": "https://www.facebook.com/mimi.marks.319",
+    "shows": [
+      "Honeys on Halsted"
+    ]
+  },
+  {
+    "name": "Naysha Lopez",
+    "instagram": "https://www.instagram.com/nayshalopez/?hl=en",
+    "twitter": "https://twitter.com/nayshalopez",
+    "facebook": "https://www.facebook.com/nayshalopez2014/",
+    "shows": [
+      "Beauties & Beaus"
+    ]
+  },
+  {
+    "name": "Granny Mattress",
+    "shows": [
+      "Charity HamBingo Mary’s"
+    ]
+  },
+  {
+    "name": "Fay Ludes",
+    "instagram": "https://www.instagram.com/fayludes/",
+    "twitter": "https://twitter.com/melisser?lang=en",
+    "facebook": "https://www.facebook.com/fay.ludes.1",
+    "shows": [
+      "Let’s Make a DIVA!"
+    ]
+  },
+  {
+    "name": "Diana Tunnel",
+    "instagram": "https://www.instagram.com/dianatunnel13/",
+    "twitter": "https://twitter.com/DiannaTunnel",
+    "facebook": "https://www.facebook.com/diana.tunnel.5",
+    "shows": [
+      "Drag Race at Mary's"
+    ]
+  },
+  {
+    "name": "Darla Dae",
+    "instagram": "https://www.instagram.com/chgodarla/",
+    "facebook": "https://www.facebook.com/darla.dae",
+    "shows": [
+      "Double 'D' Bingo"
+    ]
+  },
+  {
+    "name": "Alexandrea Diamond",
+    "instagram": "https://www.instagram.com/alexandrea.diamond/?hl=en",
+    "shows": [
+      "Throwback Thursdays"
+    ]
+  },
+  {
+    "name": "Veronica Pop",
+    "instagram": "https://www.instagram.com/vickyypop/?hl=en",
+    "twitter": "https://twitter.com/martinthelamest?lang=en",
+    "facebook": "https://www.facebook.com/VeronicaPopOfficial/",
+    "shows": [
+      "Throwback Thursdays",
+      "#POPular"
+    ]
+  },
+  {
+    "name": "Chamilla Foxx",
+    "instagram": "https://www.instagram.com/chamilla_foxx/",
+    "twitter": "https://twitter.com/chamillafoxx?lang=en",
+    "facebook": "https://www.facebook.com/chamilla.foxx",
+    "shows": [
+      "Sunday Social"
+    ]
+  }
+],
+
+const queensInsta = [
+  {
+    query: "https://www.instagram.com/trexinchicago",
+    profileUrl: "https://www.instagram.com/trexinchicago/",
+    bio: "Larger than life. Dumber than hell. ⭐️RPDR viewings at @roscoestavern [YouTube] ⭐️Host of @dragmatinee ⭐️Resident at @hardcandyky @d.i.x._milwaukee",
+    followersCount: 65025,
+    followingCount: 1852,
+    status: "Following",
+    fullName: "T REX",
+    instagramID: "180355",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 61,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/adfaa84899395612d004ad7c84c8aadd/5D4675A4/t51.2885-19/s320x320/49845470_632700483816654_184586295538876416_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1823,
+    profileName: "trexinchicago",
+    website: "https://elitequeens.com/collections/trannika-rex",
+    timestamp: "2019-04-01T04:48:12.996Z"
+  },
+  {
+    query: "https://www.instagram.com/fridalay69",
+    profileUrl: "https://www.instagram.com/fridalay69/",
+    bio: "",
+    followersCount: 1037,
+    followingCount: 234,
+    fullName: "Frida Lay",
+    instagramID: "3978860642",
+    mutualFollowersCount: 2,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/cba48214c45c9431bf5e69eacd0c40b0/5D42533A/t51.2885-19/s320x320/15538217_217053125408871_6722936862756831232_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 22,
+    profileName: "fridalay69",
+    timestamp: "2019-04-01T04:48:18.819Z"
+  },
+  {
+    query: "https://www.instagram.com/bambi.banks",
+    profileUrl: "https://www.instagram.com/bambi.banks/",
+    bio: "💥Chicago’s Princess 💥Member of Maison Couleé 💥Woman of Color 💥DM to book me please! 💥Venmo: Bambi-banks1",
+    followersCount: 9675,
+    followingCount: 1240,
+    status: "Following",
+    fullName: "Bambi Banks-Couleé",
+    instagramID: "4163973564",
+    mutualFollowersCount: 32,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/351b6c9c8e71ed35c1c77050592349ca/5D3E781A/t51.2885-19/s320x320/54238024_2106929026094814_6151288054372892672_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 207,
+    profileName: "bambi.banks",
+    website: "https://www.youtube.com/channel/UCTV7-UmOK8INXL-o9S5ypuw",
+    timestamp: "2019-04-01T04:48:23.616Z"
+  },
+  {
+    query: "https://www.instagram.com/denali_._",
+    profileUrl: "https://www.instagram.com/denali_._/",
+    bio: "Chicago’s premier Alaskan dance and ice queen ⛸ 🏆Crash Landing Cycle 21 Winner 📍Chicago, IL Booking: DM/corderozuckerman@yahoo.com",
+    followersCount: 1681,
+    followingCount: 780,
+    fullName: "Denali",
+    instagramID: "7432685186",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 14,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/428bcc93e83c1bd35cad11b5a28e0df1/5D4A3D30/t51.2885-19/s320x320/44528662_366373510773797_5489220237263896576_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 81,
+    profileName: "denali_._",
+    timestamp: "2019-04-01T04:48:29.211Z"
+  },
+  {
+    query: "https://www.instagram.com/msmalone28",
+    profileUrl: "https://www.instagram.com/msmalone28/",
+    bio: "📍 Chicago Queen 📑 Booking: mydash01@gmail.com 🐥 @msmalone28",
+    followersCount: 944,
+    followingCount: 625,
+    fullName: "💋Ashley Malone",
+    instagramID: "923959531",
+    mutualFollowersCount: 7,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/6d7e6e73462b5d1a78b94cabf5fd80b0/5D4A1B31/t51.2885-19/s320x320/19227323_1507346699329411_4342794076123299840_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 166,
+    profileName: "msmalone28",
+    website: "http://www.facebook.com/ashley.malone.14",
+    timestamp: "2019-04-01T04:48:34.919Z"
+  },
+  {
+    query: "https://www.instagram.com/kat.sass",
+    profileUrl: "https://www.instagram.com/kat.sass/",
+    bio: "👑Chicago Based Queer Nonbinary Glampire 👑Drag/Production Design/Art Direction 👑Native American/Greek Tragedy 👑Please DM to book 👑Venmo: @katsass",
+    followersCount: 11027,
+    followingCount: 2015,
+    fullName: "𝕂𝕒𝕥 𝕊𝕒𝕤𝕤",
+    instagramID: "224481659",
+    mutualFollowersCount: 26,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/3323d98df624de2eb095ffb9c89ba111/5D32DDAF/t51.2885-19/s320x320/45673485_490667418097105_7862612748352356352_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 945,
+    profileName: "kat.sass",
+    website: "https://worldofwonder.net/transformationtuesday-qwerrrkout-feat-kat-sass/",
+    timestamp: "2019-04-01T04:48:40.451Z"
+  },
+  {
+    query: "https://www.instagram.com/iamkeritraid",
+    profileUrl: "https://www.instagram.com/iamkeritraid/",
+    bio: "100% That Bitch 😘",
+    followersCount: 1042,
+    followingCount: 1384,
+    fullName: "Keri Traid",
+    instagramID: "1566264960",
+    private: "Private",
+    mutualFollowersCount: 9,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/9ae31ea2ac0366b5f94f81489e000d3e/5D2F3312/t51.2885-19/s320x320/54266446_595015444311442_7188520989909581824_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1007,
+    profileName: "iamkeritraid",
+    timestamp: "2019-04-01T04:48:43.715Z"
+  },
+  {
+    query: "https://www.instagram.com/tenderoni88",
+    profileUrl: "https://www.instagram.com/tenderoni88/",
+    bio: "👑Chicago Drag King 👑 🖍Freelance artist specializing in Airbrush/Handpainting🖍 🤓Goof Troop🤓 PIZZA TEE ⬇️⬇️⬇️ Bookings: booktenderoni@gmail.com",
+    followersCount: 10328,
+    followingCount: 1803,
+    fullName: "tenderoni88",
+    instagramID: "6373173",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 34,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/13e995a8636ec47ffde09c03a0f9ed8b/5D2B0C3A/t51.2885-19/s320x320/46231105_215610492568777_3332799123098173440_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1937,
+    profileName: "tenderoni88",
+    website: "https://tenderoni.bigcartel.com/product/tenderoni-pizza-tee",
+    timestamp: "2019-04-01T04:48:48.352Z"
+  },
+  {
+    query: "https://www.instagram.com/butchqween",
+    profileUrl: "https://www.instagram.com/butchqween/",
+    bio: "Just a chicken nugget girl in a BBQ world; Chicago",
+    followersCount: 3859,
+    followingCount: 1475,
+    fullName: "💗Alex Kay💗",
+    instagramID: "33781525",
+    mutualFollowersCount: 13,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/ebeaf92df734c2e26d944f4d54527252/5D3AD9A4/t51.2885-19/s320x320/52937583_553976341772723_2228754556773203968_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 366,
+    profileName: "butchqween",
+    website: "http://twitter.com/AlexKayJustOk",
+    timestamp: "2019-04-01T04:48:53.911Z"
+  },
+  {
+    query: "https://www.instagram.com/blondebenet",
+    profileUrl: "https://www.instagram.com/blondebenet/",
+    bio: "A thirst trap in pastels. Chicago.",
+    followersCount: 6544,
+    followingCount: 620,
+    fullName: "Blondebenét 💕💊",
+    instagramID: "31627718",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 9,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/3342e5a10216cf4733ed19ee7e9fb655/5D2CA04D/t51.2885-19/s320x320/50940469_344514352832657_5889399318237937664_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 653,
+    profileName: "blondebenet",
+    website: "http://twitter.com/blonde_benet",
+    timestamp: "2019-04-01T04:48:59.418Z"
+  },
+  {
+    query: "https://www.instagram.com/loganzass",
+    profileUrl: "https://www.instagram.com/loganzass/",
+    bio: "The Pintsized Pimpin Party Princess ✌🏽 Chicago drag queen &amp; socialite #SquadGoalsChicago Talk to me nice 😇",
+    followersCount: 2374,
+    followingCount: 1099,
+    fullName: "Logan Zass",
+    instagramID: "270615335",
+    mutualFollowersCount: 9,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/bb48186b223245b784e2ba84191c1b1a/5D43C507/t51.2885-19/s320x320/50748521_294083794552813_2422421259284381696_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 688,
+    profileName: "loganzass",
+    timestamp: "2019-04-01T04:49:04.568Z"
+  },
+  {
+    query: "https://www.instagram.com/joonageatrois",
+    profileUrl: "https://www.instagram.com/joonageatrois/",
+    bio: "Chicago drag queen Jager queen, gender monster, brat, chaotic pussy energy Host of @squadgoalschicago Joonageatrois@gmail.com",
+    followersCount: 1549,
+    followingCount: 559,
+    fullName: "Joonage À Trois",
+    instagramID: "300520601",
+    mutualFollowersCount: 8,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/030e10ab7df28aa6cbc25680911824e3/5D394BA1/t51.2885-19/s320x320/46997218_440818009784862_3017477184164986880_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 174,
+    profileName: "joonageatrois",
+    timestamp: "2019-04-01T04:49:09.388Z"
+  },
+  {
+    query: "https://www.instagram.com/theladyivory",
+    profileUrl: "https://www.instagram.com/theladyivory/",
+    bio: "💚#CholaClown from Chicago💚 👕Click Below for Merch👕",
+    followersCount: 4420,
+    followingCount: 1158,
+    fullName: "#THEIVORYLEAGUE",
+    instagramID: "31415494",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 20,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/4d0b3df6131f8d888306a9df15cca084/5D4AD8C8/t51.2885-19/s320x320/51960968_314889779378337_6930784065515683840_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1196,
+    profileName: "theladyivory",
+    website: "https://www.dragqueenmerch.com/search?q=ivory",
+    timestamp: "2019-04-01T04:49:14.577Z"
+  },
+  {
+    query: "https://www.instagram.com/claire.voyant.queen",
+    profileUrl: "https://www.instagram.com/claire.voyant.queen/",
+    bio: "Chicago Based Ethereal Shapeshifter Roscoe’s Drag Race 2018 Fan Favorite &amp; Second Place 💀 Slay Host at Berlin 💀",
+    followersCount: 4507,
+    followingCount: 1472,
+    fullName: "Claire Voyant (Nick Spindler)",
+    instagramID: "2274584267",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 14,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/b246ef70004ec4f6064ab1a87cf80ccc/5D43AC73/t51.2885-19/s320x320/52771929_384172695710068_8393887159051878400_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 458,
+    profileName: "claire.voyant.queen",
+    timestamp: "2019-04-01T04:49:18.555Z"
+  },
+  {
+    query: "https://www.instagram.com/crinklecutqueen",
+    profileUrl: "https://www.instagram.com/crinklecutqueen/",
+    bio: "Chicago drag artist, recovering carbaholic. 🤑Venmo @crinklecutqueen",
+    followersCount: 809,
+    followingCount: 596,
+    fullName: "Másha Potato",
+    instagramID: "173564140",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 6,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/1181c4aab94a68f11bdd0b27da9721e6/5D40BC83/t51.2885-19/s320x320/39245126_321538398619721_6782979199884853248_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 37,
+    profileName: "crinklecutqueen",
+    website: "http://twitter.com/crinklecutqueen",
+    timestamp: "2019-04-01T04:49:24.328Z"
+  },
+  {
+    query: "https://www.instagram.com/siichele",
+    profileUrl: "https://www.instagram.com/siichele/",
+    bio: "Qt angel/demon bb 👼🏽🔪 Queen 🦷 MUA 🦷 Queer 🦷 Libra 🦷 Chicago, IL🦷",
+    followersCount: 6067,
+    followingCount: 1488,
+    fullName: "Siichele/Michele",
+    instagramID: "7035445",
+    mutualFollowersCount: 24,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/ac7b8fa47fcba73ef5acb00ffc95b89d/5D3F3A29/t51.2885-19/s320x320/52993442_2202217859839848_8598534538160766976_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 400,
+    profileName: "siichele",
+    timestamp: "2019-04-01T04:49:28.516Z"
+  },
+  {
+    query: "https://www.instagram.com/misslailamcqueen",
+    profileUrl: "https://www.instagram.com/misslailamcqueen/",
+    bio: "Not terrible, not Gr8 either. For bookings: lailamcqueen@gmail.com",
+    followersCount: 250636,
+    followingCount: 1504,
+    fullName: "Laila McQueen",
+    instagramID: "49479585",
+    verified: "Verified",
+    mutualFollowersCount: 52,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/c01c1541be9d883f6a3c907fbc078780/5D3A8FC7/t51.2885-19/s320x320/12269932_1652815834986085_971630936_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1171,
+    profileName: "misslailamcqueen",
+    timestamp: "2019-04-01T04:49:33.836Z"
+  },
+  {
+    query: "https://www.instagram.com/sashabelley",
+    profileUrl: "https://www.instagram.com/sashabelley/",
+    bio: "",
+    followersCount: 85998,
+    followingCount: 2091,
+    fullName: "Sasha Belle",
+    instagramID: "596294452",
+    verified: "Verified",
+    mutualFollowersCount: 26,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/9e8e535948a6840c9778f3948b3bcd4c/5D2AB39C/t51.2885-19/s320x320/54196427_312652559394918_5887169852254191616_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 3354,
+    profileName: "sashabelley",
+    website: "https://www.youtube.com/channel/UC31O3PIdIoSd22oxLCWJdiQ",
+    timestamp: "2019-04-01T04:49:37.925Z"
+  },
+  {
+    query: "https://www.instagram.com/_chasitymarie_",
+    profileUrl: "https://www.instagram.com/_chasitymarie_/",
+    bio: "Everyones Dream Girl 💁🏼‍♀️ Female Impersonator/Drag Queen 💃 The Cabaret - Cincinnati, Ohio! For booking information PM me!",
+    followersCount: 10446,
+    followingCount: 1436,
+    fullName: "Chasity Marie",
+    instagramID: "1289935725",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 2,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/4628c8845ccc9f0de89c18ed68a51caf/5D4D516C/t51.2885-19/s320x320/50061688_602457636870001_2943407002811891712_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1402,
+    profileName: "_chasitymarie_",
+    timestamp: "2019-04-01T04:49:43.658Z"
+  },
+  {
+    query: "https://www.instagram.com/tyislucystoole",
+    profileUrl: "https://www.instagram.com/tyislucystoole/",
+    bio: "🎀💗💩International Black Bearded Beauty💩💗🎀 Chicago Nightlife Award Winner - 2016 Best Drag Entertainer",
+    followersCount: 34163,
+    followingCount: 1947,
+    fullName: "🎀🐷💩Lucy Stoole💩🐷🎀",
+    instagramID: "382061508",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 56,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/3ffab66986f5b1d80cdd5fe46f3e65ef/5D361803/t51.2885-19/s320x320/14659376_610472812474502_5217065038937849856_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1345,
+    profileName: "tyislucystoole",
+    website: "https://www.lucystoole.com/shop",
+    timestamp: "2019-04-01T04:49:47.835Z"
+  },
+  {
+    query: "https://www.instagram.com/aunty_chan",
+    profileUrl: "https://www.instagram.com/aunty_chan/",
+    bio: "❤️🧡💛💚💙💜💙💚💛🧡❤️ Double-D list Celebrity📍Chicago Drag Queen and Opinionated Scum ❤️🧡💛💚💙💜💙💚💛🧡❤️ IMHO EP. 4 💋⬇️",
+    followersCount: 16766,
+    followingCount: 1230,
+    status: "Following",
+    followsViewer: "Follows you",
+    fullName: "*•.¸♡ ᗩᑌᑎTY ᑕᕼᗩᑎ ♡¸.•*",
+    instagramID: "3572145048",
+    businessAccount: "Business Account",
+    businessCategory: "Grocery &amp; Convenience Stores",
+    mutualFollowersCount: 68,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/f0b2195af69b918c1baa1ed18c56d446/5D4AF54C/t51.2885-19/s320x320/51218190_377069173112153_1261515169956102144_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 193,
+    profileName: "aunty_chan",
+    website: "https://youtu.be/5zaoQCf39Sg",
+    timestamp: "2019-04-01T04:50:10.771Z"
+  },
+  {
+    query: "https://www.instagram.com/savannahwestbrooke",
+    profileUrl: "https://www.instagram.com/savannahwestbrooke/",
+    bio: "I'm simply a drag queen with a purpose and a message for the world...",
+    followersCount: 6309,
+    followingCount: 2257,
+    fullName: "Savannah Westbrooke",
+    instagramID: "4017004326",
+    businessAccount: "Business Account",
+    businessCategory: "General Interest",
+    mutualFollowersCount: 5,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/2b066187ea735bd70fb9c602599b0f02/5D2F8846/t51.2885-19/s320x320/47582438_311180572825000_2856242136188190720_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 690,
+    profileName: "savannahwestbrooke",
+    timestamp: "2019-04-01T04:50:15.570Z"
+  },
+  {
+    query: "https://www.instagram.com/auramayari",
+    profileUrl: "https://www.instagram.com/auramayari/",
+    bio: "ᜂᜇ ᜋᜌᜇᜒ DM for bookings or email: auramayari@gmail.com Hostess of Sirens of Splash every Thursday 📍Chicago",
+    followersCount: 2372,
+    followingCount: 585,
+    fullName: "Aura Mayari 🌙 Drag Queen",
+    instagramID: "5917185801",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 6,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/a1a3d5e0b5b00d090444e743a2bfffdd/5D3A8835/t51.2885-19/s320x320/52912677_2120891901535036_3596226380943065088_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 57,
+    profileName: "auramayari",
+    timestamp: "2019-04-01T04:50:20.526Z"
+  },
+  {
+    query: "https://www.instagram.com/nicozworld",
+    profileUrl: "https://www.instagram.com/nicozworld/",
+    bio: "Crash landed here in Chicago. #alienstreetwalker. Venmo-@nicozworld",
+    followersCount: 32680,
+    followingCount: 3239,
+    fullName: "Nico 👽",
+    instagramID: "175644024",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 36,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/450d71f867e0e8f5fb5f3a96612c51ea/5D4C892A/t51.2885-19/s320x320/52377309_405134256702481_4925590613857927168_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1785,
+    profileName: "nicozworld",
+    timestamp: "2019-04-01T04:50:25.748Z"
+  },
+  {
+    query: "https://www.instagram.com/monicabhillz",
+    profileUrl: "https://www.instagram.com/monicabhillz/",
+    bio: "S5 Alumni of RPDR✨’’Monica Beverly Hillz Is Very Good At Giving Face”👉Booking Info:4SOCIALSCOPE@gmail.com",
+    followersCount: 47211,
+    followingCount: 7499,
+    fullName: "Monica Beverly Hillz",
+    instagramID: "260165336",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    verified: "Verified",
+    mutualFollowersCount: 18,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/c7fbadfc9854ea5890b0056bd8d1e73e/5D44C478/t51.2885-19/s320x320/47690220_358221554758905_4047581620746584064_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 420,
+    profileName: "monicabhillz",
+    timestamp: "2019-04-01T04:50:29.759Z"
+  },
+  {
+    query: "https://www.instagram.com/imp_kid",
+    profileUrl: "https://www.instagram.com/imp_kid/",
+    bio: "ts starlet ✨ 💸 venmo @imp_kid 🤑 bookings: impunderscorekid@gmail.com",
+    followersCount: 132019,
+    followingCount: 1366,
+    fullName: "imp",
+    instagramID: "10125966",
+    verified: "Verified",
+    mutualFollowersCount: 60,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/220a6289cdae95f841b97559d2388896/5D2FD304/t51.2885-19/s320x320/51209151_539239709899381_1590668514195144704_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1093,
+    profileName: "imp_kid",
+    website: "https://www.them.us/story/imp-queen-trans-drag-queens",
+    timestamp: "2019-04-01T04:50:34.186Z"
+  },
+  {
+    query: "https://www.instagram.com/imirregulargirl",
+    profileUrl: "https://www.instagram.com/imirregulargirl/",
+    bio: "💩I’m the shits! 💋Trans Lady 💍Venmo/Paypal: imirregulargirl 📖DM for bookings 📍Chicago, IL",
+    followersCount: 1907,
+    followingCount: 552,
+    fullName: "Irregular Girl",
+    instagramID: "4104525898",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 16,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/091bc7c00b71b06285cc08eea363c930/5D328EF6/t51.2885-19/s320x320/51372188_2456159417787792_513719870043455488_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 165,
+    profileName: "imirregulargirl",
+    timestamp: "2019-04-01T04:50:38.723Z"
+  },
+  {
+    query: "https://www.instagram.com/liketotallytiffany",
+    profileUrl: "https://www.instagram.com/liketotallytiffany/",
+    bio: "The Diamond standard of dolls 💖💎💅🏻💋 ✨Chicago✨ ✨LikeTotallyTiffany@gmail.com✨ ✨@Liketotallytiff on Twitter✨",
+    followersCount: 18404,
+    followingCount: 741,
+    fullName: "Tiffany Diamond",
+    instagramID: "3988992523",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 13,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/01cd1b1166b0015aa1657c3bd52c38dc/5D2DAAA8/t51.2885-19/s320x320/50790891_254218258838818_4831604536009293824_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 142,
+    profileName: "liketotallytiffany",
+    website: "https://www.dragqueenmerch.com/collections/tiffany-diamond",
+    timestamp: "2019-04-01T04:50:43.546Z"
+  },
+  {
+    query: "https://www.instagram.com/msjasminemasters",
+    profileUrl: "https://www.instagram.com/msjasminemasters/",
+    bio: "Rupaul show , YouTube Jasmine Masters For JUSH &amp; other $25 tees and $20tanks. Hit the PayPal link leave size &amp; color in the memo @jush_merch",
+    followersCount: 241206,
+    followingCount: 1813,
+    fullName: "Jasmine JUSH Masters",
+    instagramID: "215063846",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    verified: "Verified",
+    mutualFollowersCount: 49,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/ac3c36ee1820a971093be0c6067e4540/5D4DEAFF/t51.2885-19/s320x320/53067103_473850296485005_1723285413394644992_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 4200,
+    profileName: "msjasminemasters",
+    website: "https://www.paypal.me/JnBCrew",
+    timestamp: "2019-04-01T04:50:47.567Z"
+  },
+  {
+    query: "https://www.instagram.com/thedragprincess",
+    profileUrl: "https://www.instagram.com/thedragprincess/",
+    bio: "Host/emcee/Playmate @playnashville Snap: @thedragprincess Twitter: @thedragprincess #dragllama",
+    followersCount: 79452,
+    followingCount: 1509,
+    fullName: "The. Princess.",
+    instagramID: "176629983",
+    mutualFollowersCount: 39,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/62e4dfe7f83d963986058c9c651d31fa/5D348DE2/t51.2885-19/s320x320/30086594_468301443589171_8364667341190987776_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1233,
+    profileName: "thedragprincess",
+    website: "https://www.dragqueenmerch.com/collections/the-princess",
+    timestamp: "2019-04-01T04:50:51.631Z"
+  },
+  {
+    query: "https://www.instagram.com/julia_starr__",
+    profileUrl: "https://www.instagram.com/julia_starr__/",
+    bio: "Bohemian artist I go where my Art takes me . Renaissance girl /Fashion Designer/Painter/Makeup Artist/Performer . Humbleness is key it allows u 2 grow",
+    followersCount: 6463,
+    followingCount: 2419,
+    fullName: "Julia Starr 💕💖✌️😘✌️💖💕",
+    instagramID: "969141496",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 8,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/f83638e064f4f7961743157f6078cfc5/5D4B826A/t51.2885-19/s320x320/54513306_2371220143203974_1991202904928681984_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 453,
+    profileName: "julia_starr__",
+    website: "https://www.facebook.com/tonylovesX0X0",
+    timestamp: "2019-04-01T04:50:55.878Z"
+  },
+  {
+    query: "https://www.instagram.com/traceyottomey",
+    profileUrl: "https://www.instagram.com/traceyottomey/",
+    bio: "I’m obviously a woman. You can see me at @tribenashville every Monday at 9:30PM and Thursday for Bingo at 7PM and Karaoke to follow RPDR Untucked.",
+    followersCount: 1354,
+    followingCount: 1691,
+    fullName: "TraceyOttomey",
+    instagramID: "242665343",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 3,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/8c13e496bf460931565b18bee1603419/5D34EF73/t51.2885-19/s320x320/18513529_232189897266566_4086778188074582016_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 278,
+    profileName: "traceyottomey",
+    timestamp: "2019-04-01T04:51:00.894Z"
+  },
+  {
+    query: "https://www.instagram.com/cleopockalipps",
+    profileUrl: "https://www.instagram.com/cleopockalipps/",
+    bio: "Roscoe's Drag Race Winner 2018",
+    followersCount: 863,
+    followingCount: 939,
+    fullName: "Cleo Pockalipps",
+    instagramID: "6215984552",
+    mutualFollowersCount: 6,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/7f9d221c50c215fc5cc6195b9538f9ca/5D373A16/t51.2885-19/s320x320/50855065_1314894598666233_6892635032121245696_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 47,
+    profileName: "cleopockalipps",
+    timestamp: "2019-04-01T04:51:04.983Z"
+  },
+  {
+    query: "https://www.instagram.com/kahmorahall",
+    profileUrl: "https://www.instagram.com/kahmorahall/",
+    bio: "📍Chicago ✨Mackie Girl",
+    followersCount: 5462,
+    followingCount: 454,
+    fullName: "K. Hall",
+    instagramID: "1421670968",
+    mutualFollowersCount: 20,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/b3fb85b6b624f8ff67172147b0ab4b8f/5D47B307/t51.2885-19/s320x320/40048287_2112346195751835_3954482616853331968_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 82,
+    profileName: "kahmorahall",
+    timestamp: "2019-04-01T04:51:09.954Z"
+  },
+  {
+    query: "https://www.instagram.com/dixielynncartwright",
+    profileUrl: "https://www.instagram.com/dixielynncartwright/",
+    bio: "Chicago🌃Drag queen👸🏼Camel fart🐫💨",
+    followersCount: 8423,
+    followingCount: 2050,
+    status: "Following",
+    fullName: "Dixie Lynn Cartwright",
+    instagramID: "391446331",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 32,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/4ca3c9836b8218ea201a2f756eb47144/5D41A0CF/t51.2885-19/s320x320/43180155_346383522792646_6141244861761716224_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1991,
+    profileName: "dixielynncartwright",
+    website: "https://redcap.nubic.northwestern.edu/redcap/surveys/?s=YXKMW9JFXY",
+    timestamp: "2019-04-01T04:51:14.735Z"
+  },
+  {
+    query: "https://www.instagram.com/didaswag",
+    profileUrl: "https://www.instagram.com/didaswag/",
+    bio: "#CheeseCake 💝$🎉RuPaul's Drag Race S4 royalty #Top5 Mova of 'The House Of Ritz' For Booking info please contact ZavierHairston201@gmail.com",
+    followersCount: 74168,
+    followingCount: 89,
+    fullName: "DiDa Ritz",
+    instagramID: "53515394",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    verified: "Verified",
+    mutualFollowersCount: 27,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/93da815017fec99b6380299b87315ab0/5D345DCE/t51.2885-19/s320x320/13151047_250831145305986_1036211126_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 2801,
+    profileName: "didaswag",
+    timestamp: "2019-04-01T04:51:20.118Z"
+  },
+  {
+    query: "https://www.instagram.com/danikabonet",
+    profileUrl: "https://www.instagram.com/danikabonet/",
+    bio: "The Dancing/Singing Marshmallow Hostess at Charlie's Chicago lgb(T) 💉 9/23/2018 “Are you a Danika Stanika?!”",
+    followersCount: 1214,
+    followingCount: 537,
+    fullName: "Danika Bone't",
+    instagramID: "4291786827",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 9,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/58c15f0b6d3f8ecef78d846671f01100/5D41915B/t51.2885-19/s320x320/46352163_1954049874680422_8569272629620375552_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 139,
+    profileName: "danikabonet",
+    website: "https://www.facebook.com/profile.php?id=100010982440252",
+    timestamp: "2019-04-01T04:51:24.069Z"
+  },
+  {
+    query: "https://www.instagram.com/alexisbevels",
+    profileUrl: "https://www.instagram.com/alexisbevels/",
+    bio: "🎤 Chicago’s live singing, tap dancing, roller skating queen! Winner of season 1 of @campwannakiki! 🌲 ⛺️ 🌳",
+    followersCount: 3655,
+    followingCount: 4332,
+    fullName: "Alexis Bevels ⚯͛ △⃒⃘ 🛴",
+    instagramID: "1746631900",
+    businessAccount: "Business Account",
+    businessCategory: "General Interest",
+    mutualFollowersCount: 13,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/d2aad2feede1c06ade571accd845d69d/5D2FFA3B/t51.2885-19/s320x320/32443524_176604419692617_57187081524346880_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 147,
+    profileName: "alexisbevels",
+    website: "https://www.youtube.com/channel/UCTqkoKWQ0DowWAZ0Pef_5Yg",
+    timestamp: "2019-04-01T04:51:29.859Z"
+  },
+  {
+    query: "https://www.instagram.com/myron.morgan",
+    profileUrl: "https://www.instagram.com/myron.morgan/",
+    bio: "Rupaul’s Drag Race Makeup/Wigs/Costumes @makeupbymyron “ChaCha Life” 👇👇👇",
+    followersCount: 25300,
+    followingCount: 1222,
+    fullName: "Serena ChaCha",
+    instagramID: "27262393",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    verified: "Verified",
+    mutualFollowersCount: 11,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/166695e4433509e4aa0a1a24ef77a340/5D455A0E/t51.2885-19/11373805_1621318594806044_1681582767_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 893,
+    profileName: "myron.morgan",
+    website: "https://youtu.be/EEyLpXqeCcY",
+    timestamp: "2019-04-01T04:51:34.754Z"
+  },
+  {
+    query: "https://www.instagram.com/gildawabbit",
+    profileUrl: "https://www.instagram.com/gildawabbit/",
+    bio: "It’s Wabbit Season, fire! Bookings at GildaWabbit@gmail.com 💖",
+    followersCount: 9853,
+    followingCount: 1500,
+    fullName: "Gilda Wabbit",
+    instagramID: "2226723079",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 11,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/734741be52a2938e5b9421396de7da76/5D2D75F1/t51.2885-19/s320x320/40026246_301654397311064_644948494078967808_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 892,
+    profileName: "gildawabbit",
+    website: "http://www.gildawabbit.com/",
+    timestamp: "2019-04-01T04:51:39.481Z"
+  },
+  {
+    query: "https://www.instagram.com/uminaughty",
+    profileUrl: "https://www.instagram.com/uminaughty/",
+    bio: "🙊 Louisville’s Dirty Little Secret 🙊 📆 Bookings: theuminaughty@gmail.com 📆",
+    followersCount: 1491,
+    followingCount: 949,
+    fullName: "Umi Naughty",
+    instagramID: "492387294",
+    businessAccount: "Business Account",
+    businessCategory: "Local Events",
+    mutualFollowersCount: 2,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/cd442181119c1fb8cf1756ff2325b762/5D435C43/t51.2885-19/s320x320/49679202_284148878933555_1118853390223278080_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 484,
+    profileName: "uminaughty",
+    website: "https://m.facebook.com/umiinaughttyy/",
+    timestamp: "2019-04-01T04:51:43.908Z"
+  },
+  {
+    query: "https://www.instagram.com/missgabortion",
+    profileUrl: "https://www.instagram.com/missgabortion/",
+    bio: "Reverend Mother of the Bene Gesseritt, Bearer of the Holey Barbie-Doll Crotch, the Rebel from the Waist Down. I’ll definitely sew for you. DM me!",
+    followersCount: 1925,
+    followingCount: 1930,
+    fullName: "Zsa Zsa Gabortion",
+    instagramID: "965740",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 1,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/5bffbc6b71f8e4bd1b5dceaa1945d84d/5D2936A0/t51.2885-19/s320x320/26869961_839543002900673_864448278119317504_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 3166,
+    profileName: "missgabortion",
+    timestamp: "2019-04-01T04:51:48.658Z"
+  },
+  {
+    query: "https://www.instagram.com/elektradelrio",
+    profileUrl: "https://www.instagram.com/elektradelrio/",
+    bio: "Hi everyone 👋🏽 Chanel Beauty Business Manager Entertainer &amp; MC by night ✌🏽 SC/Twitter @elektradelrio",
+    followersCount: 3853,
+    followingCount: 2785,
+    fullName: "Elektra Del Rio",
+    instagramID: "41534161",
+    mutualFollowersCount: 5,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/eaf0707c9f11282a7d0956891491c02a/5D4F7635/t51.2885-19/s320x320/41955919_260955281232761_6707250534090276864_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 294,
+    profileName: "elektradelrio",
+    timestamp: "2019-04-01T04:51:53.795Z"
+  },
+  {
+    query: "https://www.instagram.com/bon_abhijeet",
+    profileUrl: "https://www.instagram.com/bon_abhijeet/",
+    bio: "👸🏽 Slumbitch Millionaire 🏠 Chicago | ❤️ Mumbai 💋 Every THURSDAY @berlinnightclub 💋 🥰 THAT girl at @aqueerpride 🥰 ⬇️ Buy my pins ⬇️",
+    followersCount: 6941,
+    followingCount: 1890,
+    fullName: "Abhijeet 🇮🇳👳🏽👳🏾‍♀️👳🏽🇮🇳",
+    instagramID: "207167707",
+    mutualFollowersCount: 24,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/97d86e71a1dc02c7f6df8ec84a440564/5D4BE9ED/t51.2885-19/s320x320/51739974_2575683252506804_3605265732322983936_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 469,
+    profileName: "bon_abhijeet",
+    website: "https://abhijeet.bigcartel.com/",
+    timestamp: "2019-04-01T04:51:59.084Z"
+  },
+  {
+    query: "https://www.instagram.com/kenziecoulee",
+    profileUrl: "https://www.instagram.com/kenziecoulee/",
+    bio: "actual goddess / non-playable character / reptilian humanoid Maison Couleé 👑 👩‍👧‍👧✨ BOOK : kenziecoulee@gmail.com Venmo : @kenziecoulee",
+    followersCount: 12525,
+    followingCount: 1685,
+    fullName: "Ҝ乇几乙丨乇 🐲 匚ㄖㄩㄥ乇乇",
+    instagramID: "17991071",
+    mutualFollowersCount: 21,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/ac1eec2cedf917e701916bdefa480e67/5D35788B/t51.2885-19/s320x320/50574467_247231406153269_5896326885738020864_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 2081,
+    profileName: "kenziecoulee",
+    timestamp: "2019-04-01T04:52:03.161Z"
+  },
+  {
+    query: "https://www.instagram.com/_khloepark",
+    profileUrl: "https://www.instagram.com/_khloepark/",
+    bio: "📍 Chicago 🌟 Socialite 👸🏽 Homecoming Queen 2012 🎀 The girl next door... that does drag",
+    followersCount: 1816,
+    followingCount: 586,
+    fullName: "Khloe Park",
+    instagramID: "6907315573",
+    mutualFollowersCount: 13,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/8e3b398d97298131447643dabef7d1d0/5D431EDD/t51.2885-19/s320x320/52442028_1259707284177485_6217925455517843456_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 170,
+    profileName: "_khloepark",
+    timestamp: "2019-04-01T04:52:09.011Z"
+  },
+  {
+    query: "https://www.instagram.com/mimimarks11",
+    profileUrl: "https://www.instagram.com/mimimarks11/",
+    bio: "Showgirl/Entertainer from Chicago💖! #girlslikeus #transisbeautiful #MIQ2005 🦄 Snapchat/Twitter: @mimimarks11",
+    followersCount: 12415,
+    followingCount: 2354,
+    fullName: "Mimi Marks",
+    instagramID: "39542483",
+    mutualFollowersCount: 11,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/9d2953c03ca1ca6dc5f163cfa6dd564c/5D4E283E/t51.2885-19/s320x320/29095940_293625631169774_6354641656188239872_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1491,
+    profileName: "mimimarks11",
+    timestamp: "2019-04-01T04:52:13.947Z"
+  },
+  {
+    query: "https://www.instagram.com/nayshalopez",
+    profileUrl: "https://www.instagram.com/nayshalopez/",
+    bio: "RPDR S8 💄 #TheBeauty 💅🏽 Miss Continental 13/14 👑 📧 nayshalopez@gmail.com for bookings... ❤💋",
+    followersCount: 91497,
+    followingCount: 3562,
+    fullName: "Naysha Lopez",
+    instagramID: "481078287",
+    verified: "Verified",
+    mutualFollowersCount: 32,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/38eb40ebda7794c98b6b60d536faf4fc/5D3C2A78/t51.2885-19/s320x320/46411704_1201154766715423_484855774258921472_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 726,
+    profileName: "nayshalopez",
+    timestamp: "2019-04-01T04:52:19.510Z"
+  },
+  {
+    query: "https://www.instagram.com/fayludes",
+    profileUrl: "https://www.instagram.com/fayludes/",
+    bio: "💊Chicago’s Drag Disco Biscuit💊 ✨Host @maryschicago✨ Tues: Let’s Make a Diva 1st Sun: Divas Brunch 2nd Fri: Let’s Make a Diva 4th Fri: HypeHerHour 🧡🌱",
+    followersCount: 4420,
+    followingCount: 2327,
+    fullName: "Fāy Ludes",
+    instagramID: "5458537511",
+    mutualFollowersCount: 10,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/ea4ca467d510636390343c37dcf7820d/5D3B7C8F/t51.2885-19/s320x320/43143904_553440405077552_6966782853598150656_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 244,
+    profileName: "fayludes",
+    timestamp: "2019-04-01T04:52:25.186Z"
+  },
+  {
+    query: "https://www.instagram.com/dianatunnel13",
+    profileUrl: "https://www.instagram.com/dianatunnel13/",
+    bio: "Chicago's backwoods Barbie For bookings, email dianatunnel13@gmail.com",
+    followersCount: 1066,
+    followingCount: 1107,
+    fullName: "Diana Tunnel",
+    instagramID: "240207515",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 4,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/0ecb820068c81915ee419a18fe80578e/5D3CFAE3/t51.2885-19/s320x320/47693299_276593406371651_5843873313440399360_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1383,
+    profileName: "dianatunnel13",
+    timestamp: "2019-04-01T04:52:30.089Z"
+  },
+  {
+    query: "https://www.instagram.com/chgodarla",
+    profileUrl: "https://www.instagram.com/chgodarla/",
+    bio: "The Bingo Hostess at Charlie's Chicago",
+    followersCount: 423,
+    followingCount: 696,
+    fullName: "Darla Dae",
+    instagramID: "3558952197",
+    mutualFollowersCount: 0,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/640557d74515923d83777a4f114803e1/5D37D05B/t51.2885-19/s150x150/13740926_1730091973931368_1603088894_a.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 108,
+    profileName: "chgodarla",
+    timestamp: "2019-04-01T04:52:36.028Z"
+  },
+  {
+    query: "https://www.instagram.com/alexandrea.diamond",
+    profileUrl: "https://www.instagram.com/alexandrea.diamond/",
+    bio: "| Show Director • Charlies Chicago • | Miss Chicago Continental 2018-2019 | | Miss Latina Continental 2018-2019 | | Miss Primavera | Miss GLK |",
+    followersCount: 3483,
+    followingCount: 1193,
+    fullName: "Alexandrea Diamond 🇵🇷 💃🏽",
+    instagramID: "52699225",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 1,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/c2ff99efc34d0a4500892a3dd58e354c/5D382B26/t51.2885-19/s320x320/40661544_264945167683438_938728822675603456_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 125,
+    profileName: "alexandrea.diamond",
+    timestamp: "2019-04-01T04:52:42.061Z"
+  },
+  {
+    query: "https://www.instagram.com/vickyypop",
+    profileUrl: "https://www.instagram.com/vickyypop/",
+    bio: "✨Same Girl, Same✨ Host of #POPOFF &amp; #POPular at Charlie's Chicago EVERY FRIDAY &amp; SATURDAY NIGHT! 📸 youtube.com/vickyypop",
+    followersCount: 17233,
+    followingCount: 1377,
+    fullName: "🌮Veronica Pop🌮",
+    instagramID: "248524899",
+    businessAccount: "Business Account",
+    businessCategory: "Creators &amp; Celebrities",
+    mutualFollowersCount: 17,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/99d5995e5b8c89c20c368d26ce948cfe/5D34BA04/t51.2885-19/s320x320/52173643_388723338611022_7452198378059857920_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1436,
+    profileName: "vickyypop",
+    website: "http://www.veronicapop.threadless.com/",
+    timestamp: "2019-04-01T04:52:46.496Z"
+  },
+  {
+    query: "https://www.instagram.com/chamilla_foxx",
+    profileUrl: "https://www.instagram.com/chamilla_foxx/",
+    bio: "HBIC at @styledbychamilla 💇🏽‍♀️ Host of @sundaysocialchi💃🏽 2 X's in my name cause I'm extra af 😜",
+    followersCount: 5300,
+    followingCount: 1961,
+    fullName: "Chamilla Foxx 🏳️‍🌈🇲🇽",
+    instagramID: "231551770",
+    mutualFollowersCount: 16,
+    imageUrl: "https://scontent-ort2-1.cdninstagram.com/vp/9ea2e8ba35934147277db7f6b34cd28a/5D503995/t51.2885-19/s320x320/53843332_2074262452864071_1373758445110427648_n.jpg?_nc_ht=scontent-ort2-1.cdninstagram.com",
+    postsCount: 1367,
+    profileName: "chamilla_foxx",
+    website: "https://www.youtube.com/user/envyrc",
+    timestamp: "2019-04-01T04:52:51.131Z"
+  }
+]
+
+
+module.exports = {
+  bars,
+  queens,
+  queensInsta
+};


### PR DESCRIPTION
I have created three datasets that are included in the jacobogart.js file. The first is a list of gay bars in Chicago and their regular drag shows/events, the second is a list of Chicago drag queens, their social media links and the shows they perform in, and lastly is a dataset I scrapped from the queens' Instagrams. I will ideally take the bio and image URL from the third set and concatenate it into the original array of queen objects. 

Regarding the implementation of this data:

There is an app called ImprovTonight in Chicago that lists all the comedy clubs and their shows. I would like to create a similar app for gay bars and their drag shows. I feel like there is a need for this in the drag community, as most events are only posted via Facebook events, outdated bar websites, or queens' personal social media.  

The user would be able to search by bar, show, queen or day of the week. Despite the booming popularity of VH1's show RuPaul's Drag Race, many local queens are still struggling to find their audience, and I feel like a simple piece of good tech could solve that problem. 