### PR TITLE
Fix type in Queen! image(s)URL key

### DIFF
--- a/mod-2/whateverly/1901/jacobogart.js
+++ b/mod-2/whateverly/1901/jacobogart.js
@@ -490,7 +490,7 @@ const bars = [
       "frequency": "weekly",
       "host": ["Lucy Stoole"],
       "id": 1901,
-      "imagesURL": "http://i67.tinypic.com/2hh1zz7.png",
+      "imageURL": "http://i67.tinypic.com/2hh1zz7.png",
       "reoccuring": true,
       "startTime": [2200],
       "name": "Queen!"


### PR DESCRIPTION
An extra 's' in a show key was preventing the image from loading. 